### PR TITLE
Domain Partitioning

### DIFF
--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -17,6 +17,96 @@ bipp
       Returns
          The processing unit used by the context.
 
+.. py:class:: Partition()
+
+   Partition method.
+
+   .. rubric:: Static Methods
+
+   .. py:method:: auto()
+      Automatic partition method through internal heuristic.
+
+      Returns
+         :py:class:`~bipp.Partition`
+
+   .. py:method:: none()
+      No partitioning.
+
+      Returns
+         :py:class:`~bipp.Partition`
+
+   .. py:method:: grid(dimensions)
+      Grid partitioning.
+
+      Args
+         dimensions : array-like(int)
+             The grid dimensions of size three.
+
+      Returns
+         :py:class:`~bipp.Partition`
+
+
+.. py:class:: NufftSynthesisOptions()
+
+   Options for NUFFT Synthesis. Default settings are set initially.
+
+   .. rubric:: Attributes
+
+   .. py:property:: tolerance
+
+      Returns
+         Tolerance used when computing the NUFFT. Smaller value will increase accuracy but requires more operations.
+
+   .. py:property:: collect_group_size
+
+      Returns
+         The maximum number of collected datasets processed together. Larger number typically improves performance but requires more memory. Internal heuristic is used if unset.
+
+   .. py:property:: local_image_partition
+
+      Returns
+         The partition method used in the image domain. Partitioning decreases memory usage, but may come with a performance penalty.
+
+   .. py:property:: local_uvw_partition
+
+      Returns
+         The partition method used in the UVW domain. Partitioning decreases memory usage, but may come with a performance penalty.
+
+   .. rubric:: Methods
+
+   .. py:method:: set_tolerance(tol)
+
+      Args
+         tol : float
+             Tolerance used for NUFFT computation.
+      Returns
+         :py:class:`~bipp.NufftSynthesisOptions`
+
+   .. py:method:: set_collect_group_size(size)
+
+      Args
+         size : int
+             Collection group size. Must be at least 1.
+      Returns
+         :py:class:`~bipp.NufftSynthesisOptions`
+
+   .. py:method:: set_local_image_partition(p)
+
+      Args
+         p : :py:class:`~bipp.Partition`
+             Partition methid for image domain.
+      Returns
+         :py:class:`~bipp.NufftSynthesisOptions`
+
+   .. py:method:: set_local_uvw_partition(p)
+
+      Args
+         p : :py:class:`~bipp.Partition`
+             Partition methid for uvw domain.
+      Returns
+         :py:class:`~bipp.NufftSynthesisOptions`
+
+
 
 .. py:class:: NufftSynthesis(ctx, n_antenna, n_beam, n_intervals, filter, lmn_x, lmn_y, lmn_z, precision, tol)
 

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -94,7 +94,7 @@ bipp
 
       Args
          p : :py:class:`~bipp.Partition`
-             Partition methid for image domain.
+             Partition method for image domain.
       Returns
          :py:class:`~bipp.NufftSynthesisOptions`
 
@@ -102,7 +102,7 @@ bipp
 
       Args
          p : :py:class:`~bipp.Partition`
-             Partition methid for uvw domain.
+             Partition method for uvw domain.
       Returns
          :py:class:`~bipp.NufftSynthesisOptions`
 

--- a/examples/simulation/lofar_bootes_nufft.py
+++ b/examples/simulation/lofar_bootes_nufft.py
@@ -59,7 +59,7 @@ opt = bipp.NufftSynthesisOptions()
 # Set the tolerance for NUFFT, which is the maximum relative error.
 opt.set_tolerance(1e-3)
 # Set the maximum number of data packages that are processed together after collection.
-# A larger number increses memory usage, but usually improves performance.
+# A larger number increases memory usage, but usually improves performance.
 # If set to "None", an internal heuristic will be used.
 opt.set_collect_group_size(None)
 # Set the domain splitting methods for image and uvw coordinates.

--- a/examples/simulation/lofar_bootes_nufft.py
+++ b/examples/simulation/lofar_bootes_nufft.py
@@ -64,8 +64,9 @@ opt.set_collect_group_size(20)
 # Set the domain splitting methods for image and uvw coordinates.
 # Splitting decreases memory usage, but may lead to lower performance.
 # Best used with a wide spread of image or uvw coordinates.
+# Possible options are "grid", "none" or "auto"
 opt.set_local_image_partition(bipp.Partition.grid([1,1,1]))
-opt.set_local_uvw_partition(bipp.Partition.grid([1,1,1]))
+opt.set_local_uvw_partition(bipp.Partition.auto())
 precision = "single"
 
 

--- a/examples/simulation/lofar_bootes_nufft.py
+++ b/examples/simulation/lofar_bootes_nufft.py
@@ -60,13 +60,14 @@ opt = bipp.NufftSynthesisOptions()
 opt.set_tolerance(1e-3)
 # Set the maximum number of data packages that are processed together after collection.
 # A larger number increses memory usage, but usually improves performance.
-opt.set_collect_group_size(20)
+# If set to "None", an internal heuristic will be used.
+opt.set_collect_group_size(None)
 # Set the domain splitting methods for image and uvw coordinates.
 # Splitting decreases memory usage, but may lead to lower performance.
 # Best used with a wide spread of image or uvw coordinates.
 # Possible options are "grid", "none" or "auto"
 opt.set_local_image_partition(bipp.Partition.grid([1,1,1]))
-opt.set_local_uvw_partition(bipp.Partition.auto())
+opt.set_local_uvw_partition(bipp.Partition.none())
 precision = "single"
 
 

--- a/include/bipp/bipp.h
+++ b/include/bipp/bipp.h
@@ -10,6 +10,7 @@ typedef void* BippNufftSynthesis;
 typedef void* BippNufftSynthesisF;
 typedef void* BippStandardSynthesis;
 typedef void* BippStandardSynthesisF;
+typedef void* BippNufftSynthesisOptions;
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,6 +35,100 @@ BIPP_EXPORT BippError bipp_ctx_create(BippProcessingUnit pu, BippContext* ctx);
 BIPP_EXPORT BippError bipp_ctx_destroy(BippContext* ctx);
 
 /**
+ * Create Nufft Synthesis options.
+ *
+ * @param[out] opt Options handle.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_create(BippNufftSynthesisOptions* opt);
+
+/**
+ * Destroy a Nufft Synthesis handle.
+ *
+ * @param[in] opt Options handle
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_destroy(BippNufftSynthesisOptions* opt);
+
+/**
+ * Set Nufft tolerance parameter.
+ *
+ * @param[in] opt Options handle.
+ * @param[in] tol Tolerance used for computing the Nufft.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_tolerance(BippNufftSynthesisOptions opt, float tol);
+
+/**
+ * Set number of collected data packages to be processed together. Larger size will increase memory
+ * usage but improve performance.
+ *
+ * @param[in] opt Options handle.
+ * @param[in] size Group size.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_collect_group_size(BippNufftSynthesisOptions opt,
+                                                             size_t size);
+
+/**
+ * Set Nufft Synthesis image partition method to "auto".
+ *
+ * @param[in] opt Options handle.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_image_partition_auto(BippNufftSynthesisOptions opt);
+
+/**
+ * Set Nufft Synthesis image partition method to "none".
+ *
+ * @param[in] opt Options handle.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_image_partition_none(BippNufftSynthesisOptions opt);
+
+/**
+ * Set Nufft Synthesis image partition method to "grid".
+ *
+ * @param[in] opt Options handle.
+ * @param[in] dimX Grid dimension in x.
+ * @param[in] dimY Grid dimension in y.
+ * @param[in] dimZ Grid dimension in z.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_image_partition_grid(BippNufftSynthesisOptions opt,
+                                                                     size_t dimX, size_t dimY,
+                                                                     size_t dimZ);
+
+/**
+ * Set Nufft Synthesis uvw partition method to "auto".
+ *
+ * @param[in] opt Options handle.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_uvw_partition_auto(BippNufftSynthesisOptions opt);
+
+/**
+ * Set Nufft Synthesis uvw partition method to "none".
+ *
+ * @param[in] opt Options handle.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_uvw_partition_none(BippNufftSynthesisOptions opt);
+
+/**
+ * Set Nufft Synthesis uvw partition method to "grid".
+ *
+ * @param[in] opt Options handle.
+ * @param[in] dimX Grid dimension in x.
+ * @param[in] dimY Grid dimension in y.
+ * @param[in] dimZ Grid dimension in z.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_local_uvw_partition_grid(BippNufftSynthesisOptions opt,
+                                                                   size_t dimX, size_t dimY,
+                                                                   size_t dimZ);
+
+/**
  * Create a nufft synthesis plan.
  *
  * @param[in] ctx Context handle.
@@ -50,8 +145,9 @@ BIPP_EXPORT BippError bipp_ctx_destroy(BippContext* ctx);
  * @param[out] plan The output handle.
  * @return Error code or BIPP_SUCCESS.
  */
-BIPP_EXPORT BippError bipp_nufft_synthesis_create_f(BippContext ctx, float tol, size_t nAntenna,
-                                                    size_t nBeam, size_t nIntervals, size_t nFilter,
+BIPP_EXPORT BippError bipp_nufft_synthesis_create_f(BippContext ctx, BippNufftSynthesisOptions opt,
+                                                    size_t nAntenna, size_t nBeam,
+                                                    size_t nIntervals, size_t nFilter,
                                                     const BippFilter* filter, size_t nPixel,
                                                     const float* lmnX, const float* lmnY,
                                                     const float* lmnZ, BippNufftSynthesisF* plan);
@@ -73,11 +169,12 @@ BIPP_EXPORT BippError bipp_nufft_synthesis_create_f(BippContext ctx, float tol, 
  * @param[out] plan The output handle.
  * @return Error code or BIPP_SUCCESS.
  */
-BIPP_EXPORT BippError bipp_nufft_synthesis_create(BippContext ctx, double tol, size_t nAntenna,
-                                                  size_t nBeam, size_t nIntervals, size_t nFilter,
-                                                  const BippFilter* filter, size_t nPixel,
-                                                  const double* lmnX, const double* lmnY,
-                                                  const double* lmnZ, BippNufftSynthesis* plan);
+BIPP_EXPORT BippError bipp_nufft_synthesis_create(BippContext ctx, BippNufftSynthesisOptions opt,
+                                                  size_t nAntenna, size_t nBeam, size_t nIntervals,
+                                                  size_t nFilter, const BippFilter* filter,
+                                                  size_t nPixel, const double* lmnX,
+                                                  const double* lmnY, const double* lmnZ,
+                                                  BippNufftSynthesis* plan);
 
 /**
  * Destroy a nufft synthesis plan.

--- a/include/bipp/nufft_synthesis.hpp
+++ b/include/bipp/nufft_synthesis.hpp
@@ -45,7 +45,7 @@ struct NufftSynthesisOptions {
     return *this;
   }
 
-  inline auto set_collect_group_size(std::size_t size) -> NufftSynthesisOptions& {
+  inline auto set_collect_group_size(std::optional<std::size_t> size) -> NufftSynthesisOptions& {
     collectGroupSize = size;
     return *this;
   }

--- a/include/bipp/nufft_synthesis.hpp
+++ b/include/bipp/nufft_synthesis.hpp
@@ -1,17 +1,66 @@
 #pragma once
 
 #include <bipp/config.h>
+#include <bipp/enums.h>
 
+#include <array>
 #include <bipp/context.hpp>
 #include <complex>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <type_traits>
+#include <utility>
+#include <variant>
 
 /*! \cond PRIVATE */
 namespace bipp {
 /*! \endcond */
+
+struct Partition {
+
+  struct Auto {};
+
+  struct None {};
+
+  struct Grid {
+    std::array<std::size_t, 3> dimensions = {1, 1, 1};
+  };
+
+  std::variant<Partition::Auto, Partition::None, Partition::Grid> method = Partition::Auto();
+};
+
+struct NufftSynthesisOptions {
+  float tolerance = 0.001f;
+
+  std::optional<std::size_t> collectGroupSize = std::nullopt;
+
+  Partition localImagePartition = Partition{Partition::Auto()};
+
+  Partition localUVWPartition = Partition{Partition::Auto()};
+
+  inline auto set_tolerance(float tol) -> NufftSynthesisOptions& {
+    tolerance = tol;
+    return *this;
+  }
+
+  inline auto set_collect_group_size(std::size_t size) -> NufftSynthesisOptions& {
+    collectGroupSize = size;
+    return *this;
+  }
+
+  inline auto set_local_image_partition(Partition p) -> NufftSynthesisOptions& {
+    localImagePartition = std::move(p);
+    return *this;
+  }
+
+  inline auto set_local_uvw_partition(Partition p) -> NufftSynthesisOptions& {
+    localUVWPartition = std::move(p);
+    return *this;
+  }
+};
+
 
 template <typename T>
 class BIPP_EXPORT NufftSynthesis {
@@ -23,7 +72,7 @@ public:
    * Create a nufft synthesis plan.
    *
    * @param[in] ctx Context handle.
-   * @param[in] tol Target precision tolorance.
+   * @param[in] opt Options.
    * @param[in] nAntenna Number of antenna.
    * @param[in] nBeam Number of beam.
    * @param[in] nIntervals Number of intervals.
@@ -34,7 +83,7 @@ public:
    * @param[in] lmnY Array of image y coordinates of size nPixel.
    * @param[in] lmnZ Array of image z coordinates of size nPixel.
    */
-  NufftSynthesis(Context& ctx, T tol, std::size_t nAntenna, std::size_t nBeam,
+  NufftSynthesis(Context& ctx, NufftSynthesisOptions opt, std::size_t nAntenna, std::size_t nBeam,
                  std::size_t nIntervals, std::size_t nFilter, const BippFilter* filter,
                  std::size_t nPixel, const T* lmnX, const T* lmnY, const T* lmnZ);
 

--- a/include/bipp/nufft_synthesis.hpp
+++ b/include/bipp/nufft_synthesis.hpp
@@ -19,12 +19,23 @@ namespace bipp {
 /*! \endcond */
 
 struct Partition {
-
+  /**
+   * Automatic domain partition method setting.
+   */
   struct Auto {};
 
+  /**
+   * Disable domain partitioning.
+   */
   struct None {};
 
+  /**
+   * Use regular grid domain partitioning
+   */
   struct Grid {
+    /**
+     * Grid dimension.
+     */
     std::array<std::size_t, 3> dimensions = {1, 1, 1};
   };
 
@@ -32,35 +43,70 @@ struct Partition {
 };
 
 struct NufftSynthesisOptions {
+  /**
+   * The tolerance used when computing the NUFFT. Smaller value will increase accuracy but requires
+   * more operations.
+   */
   float tolerance = 0.001f;
 
+  /**
+   * The maximum number of collected datasets processed together. Larger number typically improves
+   * performance but requires more memory. Internal heuristic is used if unset.
+   */
   std::optional<std::size_t> collectGroupSize = std::nullopt;
 
+  /**
+   * The partition method used in the UVW domain. Partitioning decreases memory usage, but may come
+   * with a performance penalty.
+   */
   Partition localImagePartition = Partition{Partition::Auto()};
 
+  /**
+   * The partition method used in the image domain. Partitioning decreases memory usage, but may
+   * come with a performance penalty.
+   */
   Partition localUVWPartition = Partition{Partition::Auto()};
 
+  /**
+   * Set the tolerance.
+   *
+   * @param[in] tol Tolerance.
+   */
   inline auto set_tolerance(float tol) -> NufftSynthesisOptions& {
     tolerance = tol;
     return *this;
   }
 
+  /**
+   * Set the collection group size.
+   *
+   * @param[in] size Collection group size.
+   */
   inline auto set_collect_group_size(std::optional<std::size_t> size) -> NufftSynthesisOptions& {
     collectGroupSize = size;
     return *this;
   }
 
+  /**
+   * Set the partitioning method for the UVW domain.
+   *
+   * @param[in] p Partition method.
+   */
   inline auto set_local_image_partition(Partition p) -> NufftSynthesisOptions& {
     localImagePartition = std::move(p);
     return *this;
   }
 
+  /**
+   * Set the partitioning method for the image domain.
+   *
+   * @param[in] p Partition method.
+   */
   inline auto set_local_uvw_partition(Partition p) -> NufftSynthesisOptions& {
     localUVWPartition = std::move(p);
     return *this;
   }
 };
-
 
 template <typename T>
 class BIPP_EXPORT NufftSynthesis {

--- a/python/bipp/__init__.py
+++ b/python/bipp/__init__.py
@@ -1,1 +1,1 @@
-from .pybipp import Context, NufftSynthesis, StandardSynthesis
+from .pybipp import *

--- a/python/pybipp.cpp
+++ b/python/pybipp.cpp
@@ -388,11 +388,11 @@ PYBIND11_MODULE(pybipp, m) {
       .def(py::init())
       .def_readwrite("tolerance", &NufftSynthesisOptions::tolerance)
       .def("set_tolerance", &NufftSynthesisOptions::set_tolerance)
-      .def_readwrite("collectGroupSize", &NufftSynthesisOptions::collectGroupSize)
+      .def_readwrite("collect_group_size", &NufftSynthesisOptions::collectGroupSize)
       .def("set_collect_group_size", &NufftSynthesisOptions::set_collect_group_size)
-      .def_readwrite("localImagePartition", &NufftSynthesisOptions::localImagePartition)
+      .def_readwrite("local_image_partition", &NufftSynthesisOptions::localImagePartition)
       .def("set_local_image_partition", &NufftSynthesisOptions::set_local_image_partition)
-      .def_readwrite("localUVWPartition", &NufftSynthesisOptions::localUVWPartition)
+      .def_readwrite("local_uvw_partition", &NufftSynthesisOptions::localUVWPartition)
       .def("set_local_uvw_partition", &NufftSynthesisOptions::set_local_uvw_partition);
 
   pybind11::class_<NufftSynthesisDispatcher>(m, "NufftSynthesis")

--- a/python/pybipp.cpp
+++ b/python/pybipp.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -236,10 +237,11 @@ struct StandardSynthesisDispatcher {
 };
 
 struct NufftSynthesisDispatcher {
-  NufftSynthesisDispatcher(Context& ctx, std::size_t nAntenna, std::size_t nBeam,
-                           std::size_t nIntervals, const std::vector<std::string>& filter,
-                           const py::array& lmnX, const py::array& lmnY, const py::array& lmnZ,
-                           const std::string& precision, double tol)
+  NufftSynthesisDispatcher(Context& ctx, NufftSynthesisOptions opt, std::size_t nAntenna,
+                           std::size_t nBeam, std::size_t nIntervals,
+                           const std::vector<std::string>& filter, const py::array& lmnX,
+                           const py::array& lmnY, const py::array& lmnZ,
+                           const std::string& precision)
       : nIntervals_(nIntervals), nPixel_(lmnX.shape(0)) {
     std::vector<BippFilter> filterEnums;
     for (const auto& f : filter) {
@@ -252,9 +254,9 @@ struct NufftSynthesisDispatcher {
       check_1d_array(lmnXArray);
       check_1d_array(lmnYArray, lmnXArray.shape(0));
       check_1d_array(lmnZArray, lmnXArray.shape(0));
-      plan_ = NufftSynthesis<float>(ctx, tol, nAntenna, nBeam, nIntervals, filterEnums.size(),
-                                    filterEnums.data(), lmnXArray.shape(0), lmnXArray.data(0),
-                                    lmnYArray.data(0), lmnZArray.data(0));
+      plan_ = NufftSynthesis<float>(ctx, std::move(opt), nAntenna, nBeam, nIntervals,
+                                    filterEnums.size(), filterEnums.data(), lmnXArray.shape(0),
+                                    lmnXArray.data(0), lmnYArray.data(0), lmnZArray.data(0));
     } else if (precision == "double" || precision == "DOUBLE") {
       py::array_t<double, pybind11::array::f_style | py::array::forcecast> lmnXArray(lmnX);
       py::array_t<double, pybind11::array::f_style | py::array::forcecast> lmnYArray(lmnY);
@@ -262,9 +264,9 @@ struct NufftSynthesisDispatcher {
       check_1d_array(lmnXArray);
       check_1d_array(lmnYArray, lmnXArray.shape(0));
       check_1d_array(lmnZArray, lmnXArray.shape(0));
-      plan_ = NufftSynthesis<double>(ctx, tol, nAntenna, nBeam, nIntervals, filterEnums.size(),
-                                     filterEnums.data(), lmnXArray.shape(0), lmnXArray.data(0),
-                                     lmnYArray.data(0), lmnZArray.data(0));
+      plan_ = NufftSynthesis<double>(ctx, std::move(opt), nAntenna, nBeam, nIntervals,
+                                     filterEnums.size(), filterEnums.data(), lmnXArray.shape(0),
+                                     lmnXArray.data(0), lmnYArray.data(0), lmnZArray.data(0));
     } else {
       throw InvalidParameterError();
     }
@@ -371,14 +373,36 @@ PYBIND11_MODULE(pybipp, m) {
       .def_property_readonly("processing_unit",
            [](const Context& ctx) { return processing_unit_to_string(ctx.processing_unit()); });
 
+  pybind11::class_<Partition>(m, "Partition")
+      .def(py::init())
+      .def_static("auto", []() { return Partition{Partition::Auto()}; })
+      .def_static("none", []() { return Partition{Partition::None()}; })
+      .def_static(
+          "grid",
+          [](std::array<std::size_t, 3> dimensions) {
+            return Partition{Partition::Grid{dimensions}};
+          },
+          pybind11::arg("dimensions"));
+
+  pybind11::class_<NufftSynthesisOptions>(m, "NufftSynthesisOptions")
+      .def(py::init())
+      .def_readwrite("tolerance", &NufftSynthesisOptions::tolerance)
+      .def("set_tolerance", &NufftSynthesisOptions::set_tolerance)
+      .def_readwrite("collectGroupSize", &NufftSynthesisOptions::collectGroupSize)
+      .def("set_collect_group_size", &NufftSynthesisOptions::set_collect_group_size)
+      .def_readwrite("localImagePartition", &NufftSynthesisOptions::localImagePartition)
+      .def("set_local_image_partition", &NufftSynthesisOptions::set_local_image_partition)
+      .def_readwrite("localUVWPartition", &NufftSynthesisOptions::localUVWPartition)
+      .def("set_local_uvw_partition", &NufftSynthesisOptions::set_local_uvw_partition);
+
   pybind11::class_<NufftSynthesisDispatcher>(m, "NufftSynthesis")
-      .def(pybind11::init<Context&, std::size_t, std::size_t, std::size_t,
+      .def(pybind11::init<Context&, NufftSynthesisOptions, std::size_t, std::size_t, std::size_t,
                           const std::vector<std::string>&, const py::array&, const py::array&,
-                          const py::array&, const std::string&, double>(),
-           pybind11::arg("ctx"), pybind11::arg("n_antenna"), pybind11::arg("n_beam"),
-           pybind11::arg("n_intervals"), pybind11::arg("filter"), pybind11::arg("lmn_x"),
-           pybind11::arg("lmn_y"), pybind11::arg("lmn_y"), pybind11::arg("precision"),
-           pybind11::arg("tol"))
+                          const py::array&, const std::string&>(),
+           pybind11::arg("ctx"), pybind11::arg("opt"), pybind11::arg("n_antenna"),
+           pybind11::arg("n_beam"), pybind11::arg("n_intervals"), pybind11::arg("filter"),
+           pybind11::arg("lmn_x"), pybind11::arg("lmn_y"), pybind11::arg("lmn_y"),
+           pybind11::arg("precision"))
       .def("collect", &NufftSynthesisDispatcher::collect, pybind11::arg("n_eig"),
            pybind11::arg("wl"), pybind11::arg("intervals"), pybind11::arg("w"),
            pybind11::arg("xyz"), pybind11::arg("uvw"),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ if(BIPP_CUDA OR BIPP_ROCM)
 		gpu/nufft_synthesis.cpp
 		gpu/virtual_vis.cpp
 		gpu/standard_synthesis.cpp
+		gpu/domain_partition.cu
 		gpu/util/solver_api.cpp
 		gpu/kernels/reverse.cu
 		gpu/kernels/gram.cu
@@ -82,6 +83,8 @@ if(BIPP_BUILD_TESTS)
 	# create library with default visibility if tests are build, to allow linking to internal symbols
 	bipp_create_library(bipp_test)
 	set_target_properties(bipp_test PROPERTIES VISIBILITY_INLINES_HIDDEN FALSE CXX_VISIBILITY_PRESET default)
+	target_include_directories(bipp_test INTERFACE ${BIPP_INCLUDE_DIRS})
+	target_link_libraries(bipp_test INTERFACE ${BIPP_EXTERNAL_LIBS})
 	target_compile_options(bipp_test PUBLIC -DBIPP_STATIC_DEFINE)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ if(BIPP_CUDA OR BIPP_ROCM)
 		gpu/kernels/add_vector.cu
 		gpu/kernels/gemmexp.cu
 		gpu/kernels/center_vector.cu
+		gpu/kernels/min_max_element.cu
 		)
 endif()
 

--- a/src/context_internal.hpp
+++ b/src/context_internal.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <cassert>
-#include <functional>
 #include <memory>
-#include <tuple>
 #include <optional>
 
 #include "bipp/bipp.h"

--- a/src/gpu/domain_partition.cu
+++ b/src/gpu/domain_partition.cu
@@ -1,0 +1,381 @@
+#include <array>
+#include <cstddef>
+
+#include "bipp/config.h"
+#include "context_internal.hpp"
+#include "gpu/domain_partition.hpp"
+#include "gpu/util/cub_api.hpp"
+#include "gpu/util/kernel_launch_grid.hpp"
+#include "gpu/util/runtime.hpp"
+#include "gpu/util/runtime_api.hpp"
+#include "memory/buffer.hpp"
+
+namespace bipp {
+namespace gpu {
+
+namespace {
+using GroupIndexType = unsigned;
+using GroupSizeType = unsigned long long;
+
+template <typename T, std::size_t DIM>
+struct ArrayWrapper {
+  ArrayWrapper(const std::array<T, DIM>& a) {
+    for (std::size_t i = 0; i < DIM; ++i) data[i] = a[i];
+  }
+
+  T data[DIM];
+};
+}  // namespace
+
+template <typename T, std::size_t DIM>
+static __global__ void assign_group_kernel(std::size_t n,
+                                           ArrayWrapper<std::size_t, DIM> gridDimensions,
+                                           const T* __restrict__ minCoordsMaxGlobal,
+                                           ArrayWrapper<const T*, DIM> coord, GroupIndexType* __restrict__ out) {
+  T minCoords[DIM];
+  T maxCoords[DIM];
+  for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+    minCoords[dimIdx] = minCoordsMaxGlobal[dimIdx];
+  }
+  for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+    maxCoords[dimIdx] = minCoordsMaxGlobal[DIM + dimIdx];
+  }
+
+  T gridSpacingInv[DIM];
+  for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+    gridSpacingInv[dimIdx] = gridDimensions.data[dimIdx] / (maxCoords[dimIdx] - minCoords[dimIdx]);
+  }
+
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    GroupIndexType groupIndex = 0;
+    for (std::size_t dimIdx = DIM - 1;; --dimIdx) {
+      const T* __restrict__ coordDimPtr = coord.data[dimIdx];
+      groupIndex = groupIndex * gridDimensions.data[dimIdx] +
+                   max(min(static_cast<GroupIndexType>(gridSpacingInv[dimIdx] *
+                                                       (coordDimPtr[i] - minCoords[dimIdx])),
+                           static_cast<GroupIndexType>(gridDimensions.data[dimIdx] - 1)),
+                       GroupIndexType(0));
+
+      if (!dimIdx) break;
+    }
+
+    out[i] = groupIndex;
+  }
+}
+
+template <std::size_t BLOCK_THREADS>
+static __global__ void group_count_kernel(std::size_t nGroups, std::size_t n,
+                                          const GroupIndexType* __restrict__ in,
+                                          GroupSizeType* groupCount) {
+  __shared__ GroupIndexType inCache[BLOCK_THREADS];
+
+  for (GroupIndexType groupStart = blockIdx.y * BLOCK_THREADS; groupStart < nGroups;
+       groupStart += gridDim.y * BLOCK_THREADS) {
+    const GroupIndexType myGroup = groupStart + threadIdx.x;
+    GroupSizeType myCount = 0;
+
+    for (std::size_t idxStart = blockIdx.x * BLOCK_THREADS; idxStart < n;
+         idxStart += gridDim.x * BLOCK_THREADS) {
+      if (idxStart + threadIdx.x < n) inCache[threadIdx.x] = in[idxStart + threadIdx.x];
+      __syncthreads();
+      for (std::size_t i = 0; i < min(n - idxStart, BLOCK_THREADS); ++i) {
+        myCount += (myGroup == inCache[i]);
+      }
+    }
+    if (myGroup < nGroups && myCount) atomicAdd(groupCount + myGroup, myCount);
+  }
+}
+
+template <typename T>
+static __global__ void assign_index_kernel(std::size_t n, T* __restrict__ out) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    out[i] = i;
+  }
+}
+
+template <typename T>
+static __global__ void reverse_permut_kernel(std::size_t n, const std::size_t* __restrict__ permut,
+                                             const T* __restrict__ in, T* __restrict__ out) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    out[permut[i]] = in[i];
+  }
+}
+
+template <typename T>
+static __global__ void apply_permut_kernel(std::size_t n, const std::size_t* __restrict__ permut,
+                                           const T* __restrict__ in, T* __restrict__ out) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    out[i] = in[permut[i]];
+  }
+}
+
+template <typename T, typename>
+auto DomainPartition::grid(const std::shared_ptr<ContextInternal>& ctx,
+                           std::array<std::size_t, 3> gridDimensions, std::size_t n,
+                           std::array<const T*, 3> coord) -> DomainPartition {
+  constexpr std::size_t DIM = 3;
+
+  const auto gridSize = std::accumulate(gridDimensions.begin(), gridDimensions.end(),
+                                        std::size_t(1), std::multiplies<std::size_t>());
+  if (gridSize <= 1) return DomainPartition::none(ctx, n);
+
+  auto& q = ctx->gpu_queue();
+
+  auto permutBuffer = q.create_device_buffer<std::size_t>(n);
+  auto groupSizesBuffer = q.create_device_buffer<GroupSizeType>(gridSize);
+  auto groupBufferHost = q.create_pinned_buffer<Group>(gridSize);
+
+  // Create block to make sure buffers go out-of-scope before next sync call to safe memory
+  {
+    auto minMaxBuffer = q.create_device_buffer<T>(2 * DIM);
+    auto keyBuffer = q.create_device_buffer<GroupIndexType>(
+        n);  // GroupIndexType should be enough to enumerate groups
+    auto indicesBuffer = q.create_device_buffer<std::size_t>(n);
+    auto sortedKeyBuffer = q.create_device_buffer<GroupIndexType>(n);
+
+    // Compute the minimum and maximum in each dimension stored in minMax as
+    // (min_x, min_y, ..., max_x, max_y, ...)
+    {
+      std::size_t worksize = 0;
+      api::check_status(api::cub::DeviceReduce::Min<const T*, T*>(nullptr, worksize, nullptr,
+                                                                  nullptr, n, q.stream()));
+
+      auto workBuffer = q.create_device_buffer<char>(worksize);
+
+      for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+        api::check_status(api::cub::DeviceReduce::Min<const T*, T*>(
+            workBuffer.get(), worksize, coord[dimIdx], minMaxBuffer.get() + dimIdx, n, q.stream()));
+      }
+
+      api::check_status(api::cub::DeviceReduce::Max<const T*, T*>(nullptr, worksize, nullptr,
+                                                                  nullptr, n, q.stream()));
+      if (worksize > workBuffer.size()) workBuffer = q.create_device_buffer<char>(worksize);
+
+      for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+        api::check_status(api::cub::DeviceReduce::Max<const T*, T*>(
+            workBuffer.get(), worksize, coord[dimIdx], minMaxBuffer.get() + DIM + dimIdx, n,
+            q.stream()));
+      }
+    }
+
+    // Assign the group idx to each input element and store temporarily in the permutation array
+    {
+      constexpr int blockSize = 256;
+      const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+      const auto grid = kernel_launch_grid(q.device_prop(), {n, 1, 1}, block);
+      api::launch_kernel(assign_group_kernel<T, DIM>, grid, block, 0, q.stream(), n, gridDimensions,
+                         minMaxBuffer.get(), coord, keyBuffer.get());
+    }
+
+    // Write indices before sorting
+    {
+      constexpr int blockSize = 256;
+      const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+      const auto grid = kernel_launch_grid(q.device_prop(), {n, 1, 1}, block);
+      api::launch_kernel(assign_index_kernel<std::size_t>, grid, block, 0, q.stream(), n,
+                         indicesBuffer.get());
+    }
+
+    // Compute permutation through sorting indices and group keys
+    {
+      std::size_t workSize = 0;
+      api::cub::DeviceRadixSort::SortPairs(
+          nullptr, workSize, keyBuffer.get(), sortedKeyBuffer.get(), indicesBuffer.get(),
+          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream());
+
+      auto workBuffer = q.create_device_buffer<char>(workSize);
+      api::cub::DeviceRadixSort::SortPairs(
+          workBuffer.get(), workSize, keyBuffer.get(), sortedKeyBuffer.get(), indicesBuffer.get(),
+          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream());
+    }
+
+    // Compute the number of elements in each group
+    {
+      api::memset_async(groupSizesBuffer.get(), 0, groupSizesBuffer.size_in_bytes(), q.stream());
+
+      constexpr int blockSize = 512;
+      const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+      const auto grid =
+          kernel_launch_grid(q.device_prop(), {n, gridSize, 1}, {block.x, block.x, 1});
+      api::launch_kernel(group_count_kernel<blockSize>, grid, block, 0, q.stream(), gridSize, n,
+                         sortedKeyBuffer.get(), groupSizesBuffer.get());
+    }
+  }
+
+  // Compute group begin and size
+  {
+    auto groupSizesHostBuffer = q.create_pinned_buffer<GroupSizeType>(groupSizesBuffer.size());
+    api::memcpy_async(groupSizesHostBuffer.get(), groupSizesBuffer.get(),
+                      groupSizesBuffer.size_in_bytes(), api::flag::MemcpyDeviceToHost, q.stream());
+
+    // make sure copy operations are done
+    q.sync();
+
+    auto* __restrict__ groupsPtr = groupBufferHost.get();
+    auto* __restrict__ groupSizesPtr = groupSizesHostBuffer.get();
+
+    // number of groups is always >= 1
+    groupsPtr[0].begin = 0;
+    groupsPtr[0].size = groupSizesPtr[0];
+    // Compute group begin index
+    for (std::size_t i = 1; i < groupBufferHost.size(); ++i) {
+      groupsPtr[i].begin = groupsPtr[i - 1].size + groupsPtr[i - 1].begin;
+      groupsPtr[i].size = groupSizesPtr[i];
+    }
+  }
+
+  return DomainPartition(ctx, std::move(permutBuffer), std::move(groupBufferHost));
+}
+
+template <typename F, typename>
+auto DomainPartition::apply(const F* __restrict__ inDevice, F* __restrict__ outDevice) -> void {
+  std::visit(
+      [&](auto&& arg) {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+          auto& q = ctx_->gpu_queue();
+          constexpr int blockSize = 256;
+          const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+          const auto grid = kernel_launch_grid(q.device_prop(), {arg.size(), 1, 1}, block);
+          api::launch_kernel(apply_permut_kernel<F>, grid, block, 0, q.stream(), arg.size(),
+                             arg.get(), inDevice, outDevice);
+
+        } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+          gpu::api::memcpy_async(outDevice, inDevice, sizeof(F) * arg,
+                                 gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+        }
+      },
+      permut_);
+}
+
+template <typename F, typename>
+auto DomainPartition::apply(F* inOutDevice) -> void {
+  std::visit(
+      [&](auto&& arg) {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+          auto& q = ctx_->gpu_queue();
+          if (workBufferDevice_.size_in_bytes() < sizeof(F) * arg.size())
+            workBufferDevice_ = q.create_device_buffer<char>(sizeof(F) * arg.size());
+
+          auto workPtr = reinterpret_cast<F*>(workBufferDevice_.get());
+
+          gpu::api::memcpy_async(workPtr, inOutDevice, sizeof(F) * arg.size(),
+                                 gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+
+          constexpr int blockSize = 256;
+          const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+          const auto grid = kernel_launch_grid(q.device_prop(), {arg.size(), 1, 1}, block);
+          api::launch_kernel(apply_permut_kernel<F>, grid, block, 0, q.stream(), arg.size(),
+                             arg.get(), workPtr, inOutDevice);
+        }
+      },
+      permut_);
+}
+
+template <typename F, typename>
+auto DomainPartition::reverse(const F* __restrict__ inDevice, F* __restrict__ outDevice) -> void {
+  std::visit(
+      [&](auto&& arg) {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+          auto& q = ctx_->gpu_queue();
+          constexpr int blockSize = 256;
+          const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+          const auto grid = kernel_launch_grid(q.device_prop(), {arg.size(), 1, 1}, block);
+          api::launch_kernel(reverse_permut_kernel<F>, grid, block, 0, q.stream(), arg.size(),
+                             arg.get(), inDevice, outDevice);
+
+        } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+          gpu::api::memcpy_async(outDevice, inDevice, sizeof(F) * arg,
+                                 gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+        }
+      },
+      permut_);
+}
+
+template <typename F, typename>
+auto DomainPartition::reverse(F* inOutDevice) -> void {
+  std::visit(
+      [&](auto&& arg) {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+          auto& q = ctx_->gpu_queue();
+
+          if (workBufferDevice_.size_in_bytes() < sizeof(F) * arg.size())
+            workBufferDevice_ = q.create_device_buffer<char>(sizeof(F) * arg.size());
+
+          auto workPtr = reinterpret_cast<F*>(workBufferDevice_.get());
+
+          gpu::api::memcpy_async(workPtr, inOutDevice, sizeof(F) * arg.size(),
+                                 gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+
+          constexpr int blockSize = 256;
+          const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
+          const auto grid = kernel_launch_grid(q.device_prop(), {arg.size(), 1, 1}, block);
+          api::launch_kernel(reverse_permut_kernel<F>, grid, block, 0, q.stream(), arg.size(),
+                             arg.get(), workPtr, inOutDevice);
+        }
+      },
+      permut_);
+}
+
+template auto DomainPartition::grid<float>(const std::shared_ptr<ContextInternal>& ctx,
+                                           std::array<std::size_t, 3> gridDimensions, std::size_t n,
+                                           std::array<const float*, 3> coord) -> DomainPartition;
+
+template auto DomainPartition::grid<double>(const std::shared_ptr<ContextInternal>& ctx,
+                                            std::array<std::size_t, 3> gridDimensions,
+                                            std::size_t n, std::array<const double*, 3> coord)
+    -> DomainPartition;
+
+template auto DomainPartition::apply<float>(const float* __restrict__ inDevice,
+                                            float* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::apply<double>(const double* __restrict__ inDevice,
+                                             double* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::apply<float>(float* inOutDevice) -> void;
+
+template auto DomainPartition::apply<double>(double* inOutDevice) -> void;
+
+template auto DomainPartition::apply<api::ComplexFloatType>(api::ComplexFloatType* inOutDevice)
+    -> void;
+
+template auto DomainPartition::apply<api::ComplexDoubleType>(api::ComplexDoubleType* inOutDevice)
+    -> void;
+
+template auto DomainPartition::apply<api::ComplexFloatType>(
+    const api::ComplexFloatType* __restrict__ inDevice,
+    api::ComplexFloatType* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::apply<api::ComplexDoubleType>(
+    const api::ComplexDoubleType* __restrict__ inDevice,
+    api::ComplexDoubleType* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::reverse<float>(const float* __restrict__ inDevice,
+                                              float* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::reverse<double>(const double* __restrict__ inDevice,
+                                               double* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::reverse<float>(float* inOutDevice) -> void;
+
+template auto DomainPartition::reverse<double>(double* inOutDevice) -> void;
+
+template auto DomainPartition::reverse<api::ComplexFloatType>(api::ComplexFloatType* inOutDevice)
+    -> void;
+
+template auto DomainPartition::reverse<api::ComplexDoubleType>(api::ComplexDoubleType* inOutDevice)
+    -> void;
+
+template auto DomainPartition::reverse<api::ComplexFloatType>(
+    const api::ComplexFloatType* __restrict__ inDevice,
+    api::ComplexFloatType* __restrict__ outDevice) -> void;
+
+template auto DomainPartition::reverse<api::ComplexDoubleType>(
+    const api::ComplexDoubleType* __restrict__ inDevice,
+    api::ComplexDoubleType* __restrict__ outDevice) -> void;
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/domain_partition.cu
+++ b/src/gpu/domain_partition.cu
@@ -179,14 +179,14 @@ auto DomainPartition::grid(const std::shared_ptr<ContextInternal>& ctx,
     // Compute permutation through sorting indices and group keys
     {
       std::size_t workSize = 0;
-      api::cub::DeviceRadixSort::SortPairs(
+      api::check_status(api::cub::DeviceRadixSort::SortPairs(
           nullptr, workSize, keyBuffer.get(), sortedKeyBuffer.get(), indicesBuffer.get(),
-          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream());
+          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream()));
 
       auto workBuffer = q.create_device_buffer<char>(workSize);
-      api::cub::DeviceRadixSort::SortPairs(
+      api::check_status(api::cub::DeviceRadixSort::SortPairs(
           workBuffer.get(), workSize, keyBuffer.get(), sortedKeyBuffer.get(), indicesBuffer.get(),
-          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream());
+          permutBuffer.get(), n, 0, sizeof(GroupIndexType) * 8, q.stream()));
     }
 
     // Compute the number of elements in each group

--- a/src/gpu/domain_partition.hpp
+++ b/src/gpu/domain_partition.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+
+#include "bipp/config.h"
+#include "context_internal.hpp"
+#include "gpu/util/runtime_api.hpp"
+#include "memory/buffer.hpp"
+
+namespace bipp {
+namespace gpu {
+
+class DomainPartition {
+public:
+  struct Group {
+    std::size_t begin = 0;
+    std::size_t size = 0;
+  };
+
+  static auto none(const std::shared_ptr<ContextInternal>& ctx, std::size_t n) {
+    Buffer<Group> groupsHost(ctx->host_alloc(), 1);
+    *groupsHost.get() = Group{0, n};
+    return DomainPartition(ctx, n, std::move(groupsHost));
+  }
+
+  template <typename T,
+            typename = std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
+  static auto grid(const std::shared_ptr<ContextInternal>& ctx,
+                   std::array<std::size_t, 3> gridDimensions, std::size_t n,
+                   std::array<const T*, 3> coord) -> DomainPartition;
+
+  inline auto groups() const -> const Buffer<Group>& { return groupsHost_; }
+
+  inline auto num_elements() const -> std::size_t {
+    return std::visit(
+        [&](auto&& arg) -> std::size_t {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            return arg.size();
+          } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+            return arg;
+          }
+          return 0;
+        },
+        permut_);
+  }
+
+  template <typename F,
+            typename = std::enable_if_t<std::is_same_v<F, float> || std::is_same_v<F, double> ||
+                                        std::is_same_v<F, gpu::api::ComplexFloatType> ||
+                                        std::is_same_v<F, gpu::api::ComplexDoubleType>>>
+  auto apply(const F* __restrict__ inDevice, F* __restrict__ outDevice) -> void;
+
+  template <typename F,
+            typename = std::enable_if_t<std::is_same_v<F, float> || std::is_same_v<F, double> ||
+                                        std::is_same_v<F, gpu::api::ComplexFloatType> ||
+                                        std::is_same_v<F, gpu::api::ComplexDoubleType>>>
+  auto apply(F* inOutDevice) -> void;
+
+  template <typename F,
+            typename = std::enable_if_t<std::is_same_v<F, float> || std::is_same_v<F, double> ||
+                                        std::is_same_v<F, gpu::api::ComplexFloatType> ||
+                                        std::is_same_v<F, gpu::api::ComplexDoubleType>>>
+  auto reverse(const F* __restrict__ inDevice, F* __restrict__ outDevice) -> void;
+
+  template <typename F,
+            typename = std::enable_if_t<std::is_same_v<F, float> || std::is_same_v<F, double> ||
+                                        std::is_same_v<F, gpu::api::ComplexFloatType> ||
+                                        std::is_same_v<F, gpu::api::ComplexDoubleType>>>
+  auto reverse(F* inOutDevice) -> void;
+
+private:
+  explicit DomainPartition(std::shared_ptr<ContextInternal> ctx, Buffer<std::size_t> permut,
+                           Buffer<Group> groupsHost)
+      : ctx_(std::move(ctx)), permut_(std::move(permut)), groupsHost_(std::move(groupsHost)) {}
+
+  explicit DomainPartition(std::shared_ptr<ContextInternal> ctx, std::size_t size,
+                           Buffer<Group> groupsHost)
+      : ctx_(std::move(ctx)), permut_(size), groupsHost_(std::move(groupsHost)) {}
+
+  std::shared_ptr<ContextInternal> ctx_;
+  std::variant<std::size_t, Buffer<std::size_t>> permut_;
+  Buffer<Group> groupsHost_;
+  Buffer<char> workBufferDevice_;
+};
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/kernels/center_vector.cu
+++ b/src/gpu/kernels/center_vector.cu
@@ -24,7 +24,6 @@ auto center_vector(Queue& q, std::size_t n, T* vec) -> void {
   std::size_t worksize = 0;
   api::check_status(
       api::cub::DeviceReduce::Sum<const T*, T*>(nullptr, worksize, nullptr, nullptr, n, q.stream()));
-  worksize -= sizeof(T);
 
   auto workBuffer = q.create_device_buffer<char>(sizeof(T) + worksize);
 

--- a/src/gpu/kernels/min_max_element.cu
+++ b/src/gpu/kernels/min_max_element.cu
@@ -1,0 +1,49 @@
+#include <cstddef>
+
+#include "bipp//config.h"
+#include "gpu/util/cub_api.hpp"
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+
+template <typename T>
+auto min_element(Queue& q, std::size_t n, const T* x, T* minElement) -> void {
+  std::size_t worksize = 0;
+  api::check_status(api::cub::DeviceReduce::Min<const T*, T*>(nullptr, worksize, nullptr, nullptr,
+                                                              n, q.stream()));
+
+  auto workBuffer = q.create_device_buffer<char>(worksize);
+
+  api::check_status(api::cub::DeviceReduce::Min<const T*, T*>(workBuffer.get(), worksize, x,
+                                                              minElement, n, q.stream()));
+}
+
+
+template <typename T>
+auto max_element(Queue& q, std::size_t n, const T* x, T* maxElement) -> void {
+  std::size_t worksize = 0;
+  api::check_status(api::cub::DeviceReduce::Max<const T*, T*>(nullptr, worksize, nullptr, nullptr,
+                                                              n, q.stream()));
+
+  auto workBuffer = q.create_device_buffer<char>(worksize);
+
+  api::check_status(api::cub::DeviceReduce::Max<const T*, T*>(workBuffer.get(), worksize, x,
+                                                              maxElement, n, q.stream()));
+}
+
+template auto min_element<float>(Queue& q, std::size_t n, const float* x, float* minElement)
+    -> void;
+
+template auto min_element<double>(Queue& q, std::size_t n, const double* x, double* minElement)
+    -> void;
+
+template auto max_element<float>(Queue& q, std::size_t n, const float* x, float* maxElement)
+    -> void;
+
+template auto max_element<double>(Queue& q, std::size_t n, const double* x, double* maxElement)
+    -> void;
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/kernels/min_max_element.cu
+++ b/src/gpu/kernels/min_max_element.cu
@@ -1,6 +1,6 @@
 #include <cstddef>
 
-#include "bipp//config.h"
+#include "bipp/config.h"
 #include "gpu/util/cub_api.hpp"
 #include "gpu/util/queue.hpp"
 #include "gpu/util/runtime_api.hpp"

--- a/src/gpu/kernels/min_max_element.hpp
+++ b/src/gpu/kernels/min_max_element.hpp
@@ -2,7 +2,7 @@
 
 #include <cstddef>
 
-#include "bipp//config.h"
+#include "bipp/config.h"
 #include "gpu/util/queue.hpp"
 #include "gpu/util/runtime_api.hpp"
 

--- a/src/gpu/kernels/min_max_element.hpp
+++ b/src/gpu/kernels/min_max_element.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+
+#include "bipp//config.h"
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+
+template <typename T>
+auto min_element(Queue& q, std::size_t n, const T* x, T* minElement) -> void;
+
+template <typename T>
+auto max_element(Queue& q, std::size_t n, const T* x, T* maxElement) -> void;
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/nufft_synthesis.cpp
+++ b/src/gpu/nufft_synthesis.cpp
@@ -12,44 +12,59 @@
 #include "gpu/kernels/add_vector.hpp"
 #include "gpu/nufft_3d3.hpp"
 #include "gpu/util/runtime_api.hpp"
+#include "gpu/util/device_pointer.hpp"
 #include "gpu/virtual_vis.hpp"
 
 namespace bipp {
 namespace gpu {
 
 template <typename T>
-NufftSynthesis<T>::NufftSynthesis(std::shared_ptr<ContextInternal> ctx, T tol, std::size_t nAntenna,
-                                  std::size_t nBeam, std::size_t nIntervals, std::size_t nFilter,
-                                  const BippFilter* filterHost, std::size_t nPixel, const T* lmnX,
-                                  const T* lmnY, const T* lmnZ)
+NufftSynthesis<T>::NufftSynthesis(std::shared_ptr<ContextInternal> ctx, NufftSynthesisOptions opt,
+                                  std::size_t nAntenna, std::size_t nBeam, std::size_t nIntervals,
+                                  std::size_t nFilter, const BippFilter* filterHost,
+                                  std::size_t nPixel, const T* lmnX, const T* lmnY, const T* lmnZ)
     : ctx_(std::move(ctx)),
-      tol_(tol),
+      opt_(std::move(opt)),
       nIntervals_(nIntervals),
       nFilter_(nFilter),
       nPixel_(nPixel),
       nAntenna_(nAntenna),
       nBeam_(nBeam),
-      inputCount_(0) {
+      imgPartition_(DomainPartition::none(ctx_, nPixel)),
+      collectCount_(0) {
   auto& queue = ctx_->gpu_queue();
   filterHost_ = queue.create_host_buffer<BippFilter>(nFilter_);
   std::memcpy(filterHost_.get(), filterHost, sizeof(BippFilter) * nFilter_);
-  lmnX_ = queue.create_device_buffer<T>(nPixel_);
-  api::memcpy_async(lmnX_.get(), lmnX, sizeof(T) * nPixel_, api::flag::MemcpyDeviceToDevice,
-                    queue.stream());
-  lmnY_ = queue.create_device_buffer<T>(nPixel_);
-  api::memcpy_async(lmnY_.get(), lmnY, sizeof(T) * nPixel_, api::flag::MemcpyDeviceToDevice,
-                    queue.stream());
-  lmnZ_ = queue.create_device_buffer<T>(nPixel_);
-  api::memcpy_async(lmnZ_.get(), lmnZ, sizeof(T) * nPixel_, api::flag::MemcpyDeviceToDevice,
-                    queue.stream());
 
-  // use at most 33% of memory more accumulation, but not more than 200
-  // iterations. TODO: find optimum
-  std::size_t freeMem, totalMem;
-  api::mem_get_info(&freeMem, &totalMem);
-  nMaxInputCount_ =
-      (totalMem / 3) / (nIntervals_ * nFilter_ * nAntenna_ * nAntenna_ * sizeof(std::complex<T>));
-  nMaxInputCount_ = std::min<std::size_t>(std::max<std::size_t>(1, nMaxInputCount_), 200);
+  std::visit(
+      [&](auto&& arg) -> void {
+        using ArgType = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<ArgType, Partition::Grid>) {
+          imgPartition_ =
+              DomainPartition::grid<T>(ctx_, arg.dimensions, nPixel_, {lmnX, lmnY, lmnZ});
+        }
+      },
+      opt_.localImagePartition.method);
+
+  lmnX_ = queue.create_device_buffer<T>(nPixel_);
+  lmnY_ = queue.create_device_buffer<T>(nPixel_);
+  lmnZ_ = queue.create_device_buffer<T>(nPixel_);
+
+  imgPartition_.apply(lmnX, lmnX_.get());
+  imgPartition_.apply(lmnY, lmnY_.get());
+  imgPartition_.apply(lmnZ, lmnZ_.get());
+
+  if (opt_.collectGroupSize && opt_.collectGroupSize.value() > 0) {
+    nMaxInputCount_ = opt_.collectGroupSize.value();
+  } else {
+    // use at most 33% of memory more accumulation, but not more than 200
+    // iterations.
+    std::size_t freeMem, totalMem;
+    api::mem_get_info(&freeMem, &totalMem);
+    nMaxInputCount_ =
+        (totalMem / 3) / (nIntervals_ * nFilter_ * nAntenna_ * nAntenna_ * sizeof(std::complex<T>));
+    nMaxInputCount_ = std::min<std::size_t>(std::max<std::size_t>(1, nMaxInputCount_), 200);
+  }
 
   const auto virtualVisBufferSize =
       nIntervals_ * nFilter_ * nAntenna_ * nAntenna_ * nMaxInputCount_;
@@ -70,13 +85,13 @@ auto NufftSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals, std:
   auto& queue = ctx_->gpu_queue();
 
   // store coordinates
-  api::memcpy_async(uvwX_.get() + inputCount_ * nAntenna_ * nAntenna_, uvw,
+  api::memcpy_async(uvwX_.get() + collectCount_ * nAntenna_ * nAntenna_, uvw,
                     sizeof(T) * nAntenna_ * nAntenna_, api::flag::MemcpyDeviceToDevice,
                     queue.stream());
-  api::memcpy_async(uvwY_.get() + inputCount_ * nAntenna_ * nAntenna_, uvw + lduvw,
+  api::memcpy_async(uvwY_.get() + collectCount_ * nAntenna_ * nAntenna_, uvw + lduvw,
                     sizeof(T) * nAntenna_ * nAntenna_, api::flag::MemcpyDeviceToDevice,
                     queue.stream());
-  api::memcpy_async(uvwZ_.get() + inputCount_ * nAntenna_ * nAntenna_, uvw + 2 * lduvw,
+  api::memcpy_async(uvwZ_.get() + collectCount_ * nAntenna_ * nAntenna_, uvw + 2 * lduvw,
                     sizeof(T) * nAntenna_ * nAntenna_, api::flag::MemcpyDeviceToDevice,
                     queue.stream());
 
@@ -96,15 +111,15 @@ auto NufftSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals, std:
       eigh<T>(*ctx_, nBeam_, nEig, g.get(), nBeam_, nullptr, 0, &nEigOut, d.get(), v.get(), nBeam_);
   }
 
-  auto virtVisPtr = virtualVis_.get() + inputCount_ * nAntenna_ * nAntenna_;
+  auto virtVisPtr = virtualVis_.get() + collectCount_ * nAntenna_ * nAntenna_;
 
   virtual_vis(*ctx_, nFilter_, filterHost_.get(), nIntervals_, intervals, ldIntervals, nEig,
               d.get(), nAntenna_, v.get(), nBeam_, nBeam_, w, ldw, virtVisPtr,
               nMaxInputCount_ * nIntervals_ * nAntenna_ * nAntenna_,
               nMaxInputCount_ * nAntenna_ * nAntenna_, nAntenna_);
 
-  ++inputCount_;
-  if (inputCount_ >= nMaxInputCount_) {
+  ++collectCount_;
+  if (collectCount_ >= nMaxInputCount_) {
     computeNufft();
   }
 }
@@ -113,12 +128,23 @@ template <typename T>
 auto NufftSynthesis<T>::computeNufft() -> void {
   auto& queue = ctx_->gpu_queue();
 
-  if (inputCount_) {
+  if (collectCount_) {
     auto output = queue.create_device_buffer<api::ComplexType<T>>(nPixel_);
     auto outputPtr = output.get();
-    queue.sync();  // cufinufft cannot be asigned a stream
-    Nufft3d3<T> transform(1, tol_, 1, nAntenna_ * nAntenna_ * inputCount_, uvwX_.get(), uvwY_.get(),
-                          uvwZ_.get(), nPixel_, lmnX_.get(), lmnY_.get(), lmnZ_.get());
+
+    const auto nInputPoints = nAntenna_ * nAntenna_ * collectCount_;
+
+    auto inputPartition = DomainPartition::none(ctx_, nInputPoints);
+
+    std::visit(
+        [&](auto&& arg) -> void {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Partition::Grid>) {
+            inputPartition = DomainPartition::grid<T>(ctx_, arg.dimensions, nInputPoints,
+                                                      {uvwX_.get(), uvwY_.get(), uvwZ_.get()});
+          }
+        },
+        opt_.localUVWPartition.method);
 
     const auto ldVirtVis3 = nAntenna_;
     const auto ldVirtVis2 = nMaxInputCount_ * nAntenna_ * ldVirtVis3;
@@ -126,19 +152,43 @@ auto NufftSynthesis<T>::computeNufft() -> void {
 
     for (std::size_t i = 0; i < nFilter_; ++i) {
       for (std::size_t j = 0; j < nIntervals_; ++j) {
-        auto imgPtr = img_.get() + (j + i * nIntervals_) * nPixel_;
-        transform.execute(virtualVis_.get() + i * ldVirtVis1 + j * ldVirtVis2, outputPtr);
+        inputPartition.apply(virtualVis_.get() + i * ldVirtVis1 + j * ldVirtVis2);
+      }
+    }
 
-        // use default stream to match cufiNUFFT
-        queue.sync_with_stream(nullptr);
-        add_vector_real_to_complex<T>(queue, nPixel_, outputPtr, imgPtr);
-        queue.signal_stream(nullptr);
+    inputPartition.apply(uvwX_.get());
+    inputPartition.apply(uvwY_.get());
+    inputPartition.apply(uvwZ_.get());
+
+    queue.signal_stream(nullptr);  // cufinufft uses default stream
+
+    for (const auto& [inputBegin, inputSize] : inputPartition.groups()) {
+      if (!inputSize) continue;
+      for (const auto& [imgBegin, imgSize] : imgPartition_.groups()) {
+        if (!imgSize) continue;
+
+        Nufft3d3<T> transform(1, opt_.tolerance, 1, inputSize, uvwX_.get() + inputBegin,
+                              uvwY_.get() + inputBegin, uvwZ_.get() + inputBegin, imgSize,
+                              lmnX_.get() + imgBegin, lmnY_.get() + imgBegin,
+                              lmnZ_.get() + imgBegin);
+
+        for (std::size_t i = 0; i < nFilter_; ++i) {
+          for (std::size_t j = 0; j < nIntervals_; ++j) {
+            auto imgPtr = img_.get() + (j + i * nIntervals_) * nPixel_ + imgBegin;
+            transform.execute(virtualVis_.get() + i * ldVirtVis1 + j * ldVirtVis2 + inputBegin,
+                              outputPtr);
+
+            // add dependency on default stream for correct ordering
+            queue.sync_with_stream(nullptr);
+            add_vector_real_to_complex<T>(queue, imgSize, outputPtr, imgPtr);
+            queue.signal_stream(nullptr);
+          }
+        }
       }
     }
   }
 
-  api::stream_synchronize(nullptr);  // cufinufft cannot be asigned a stream
-  inputCount_ = 0;
+  collectCount_ = 0;
 }
 
 template <typename T>
@@ -156,9 +206,20 @@ auto NufftSynthesis<T>::get(BippFilter f, T* outHostOrDevice, std::size_t ld) ->
   }
   if (index == nFilter_) throw InvalidParameterError();
 
-  api::memcpy_2d_async(outHostOrDevice, ld * sizeof(T), img_.get() + index * nIntervals_ * nPixel_,
-                       nPixel_ * sizeof(T), nPixel_ * sizeof(T), nIntervals_,
-                       api::flag::MemcpyDefault, queue.stream());
+  if (is_device_ptr(outHostOrDevice)) {
+    for (std::size_t i = 0; i < nIntervals_; ++i) {
+      imgPartition_.reverse(img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_,
+                            outHostOrDevice + i * ld);
+    }
+  } else {
+    auto workBuffer = queue.create_device_buffer<T>(nPixel_);
+    for (std::size_t i = 0; i < nIntervals_; ++i) {
+      imgPartition_.reverse(img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_,
+                            workBuffer.get());
+      gpu::api::memcpy_async(outHostOrDevice + i * ld, workBuffer.get(), workBuffer.size_in_bytes(),
+                             gpu::api::flag::MemcpyDefault, queue.stream());
+    }
+  }
 }
 
 template class NufftSynthesis<float>;

--- a/src/gpu/nufft_synthesis.hpp
+++ b/src/gpu/nufft_synthesis.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "bipp/config.h"
+#include "bipp/nufft_synthesis.hpp"
 #include "context_internal.hpp"
+#include "gpu/domain_partition.hpp"
 #include "gpu/util/runtime_api.hpp"
 #include "memory/buffer.hpp"
 
@@ -11,10 +13,10 @@ namespace gpu {
 template <typename T>
 class NufftSynthesis {
 public:
-  NufftSynthesis(std::shared_ptr<ContextInternal> ctx, T tol, std::size_t nAntenna,
-                 std::size_t nBeam, std::size_t nIntervals, std::size_t nFilter,
-                 const BippFilter* filterHost, std::size_t nPixel, const T* lmnX, const T* lmnY,
-                 const T* lmnZ);
+  NufftSynthesis(std::shared_ptr<ContextInternal> ctx, NufftSynthesisOptions opt,
+                 std::size_t nAntenna, std::size_t nBeam, std::size_t nIntervals,
+                 std::size_t nFilter, const BippFilter* filterHost, std::size_t nPixel,
+                 const T* lmnX, const T* lmnY, const T* lmnZ);
 
   auto collect(std::size_t nEig, T wl, const T* intervals, std::size_t ldIntervals,
                const api::ComplexType<T>* s, std::size_t lds, const api::ComplexType<T>* w,
@@ -29,12 +31,13 @@ private:
   auto computeNufft() -> void;
 
   std::shared_ptr<ContextInternal> ctx_;
-  const T tol_;
+  NufftSynthesisOptions opt_;
   const std::size_t nIntervals_, nFilter_, nPixel_, nAntenna_, nBeam_;
   Buffer<BippFilter> filterHost_;
   Buffer<T> lmnX_, lmnY_, lmnZ_;
+  DomainPartition imgPartition_;
 
-  std::size_t nMaxInputCount_, inputCount_;
+  std::size_t nMaxInputCount_, collectCount_;
   Buffer<api::ComplexType<T>> virtualVis_;
   Buffer<T> uvwX_, uvwY_, uvwZ_;
   Buffer<T> img_;

--- a/src/host/domain_partition.hpp
+++ b/src/host/domain_partition.hpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <type_traits>
+#include <variant>
+
+#include "bipp/config.h"
+#include "context_internal.hpp"
+#include "memory/buffer.hpp"
+
+namespace bipp {
+namespace host {
+
+class DomainPartition {
+public:
+  struct Group {
+    std::size_t begin = 0;
+    std::size_t size = 0;
+  };
+
+  static auto none(const std::shared_ptr<ContextInternal>& ctx,std::size_t n ) {
+    Buffer<Group> groups(ctx->host_alloc(), 1);
+    *groups.get() = Group{0, n};
+    return DomainPartition(ctx, n, std::move(groups));
+  }
+
+  template <typename T, std::size_t DIM>
+  static auto grid(const std::shared_ptr<ContextInternal>& ctx, std::array<std::size_t, DIM> gridDimensions,
+                   std::size_t n, std::array<const T*, DIM> coord) -> DomainPartition {
+    const auto gridSize = std::accumulate(gridDimensions.begin(), gridDimensions.end(),
+                                          std::size_t(1), std::multiplies<std::size_t>());
+    if (gridSize <= 1) return DomainPartition::none(ctx, n);
+
+    std::array<T, DIM> minCoord, maxCoord;
+
+    for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+      minCoord[dimIdx] = *std::min_element(coord[dimIdx], coord[dimIdx] + n);
+      maxCoord[dimIdx] = *std::max_element(coord[dimIdx], coord[dimIdx] + n);
+    }
+
+    Buffer<Group> groups(ctx->host_alloc(), gridSize);
+    auto* __restrict__ groupsPtr = groups.get();
+    std::memset(groupsPtr, 0, groups.size_in_bytes());
+
+    Buffer<std::size_t> permut(ctx->host_alloc(), n);
+    auto* __restrict__ permutPtr = permut.get();
+
+    std::array<T, DIM> gridSpacingInv;
+    for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
+      gridSpacingInv[dimIdx] = gridDimensions[dimIdx] / (maxCoord[dimIdx] - minCoord[dimIdx]);
+    }
+
+    // Compute the assigned group index in grid for each data point and store temporarily in permut
+    // array. Increment groups array of following group each time, such that the size of the
+    // previous group is computed.
+    for (std::size_t i = 0; i < n; ++i) {
+      std::size_t groupIndex = 0;
+      for (std::size_t dimIdx = DIM - 1;; --dimIdx) {
+        groupIndex = groupIndex * gridDimensions[dimIdx] +
+                     std::max<std::size_t>(
+                         std::min(static_cast<std::size_t>(gridSpacingInv[dimIdx] *
+                                                           (coord[dimIdx][i] - minCoord[dimIdx])),
+                                  gridDimensions[dimIdx] - 1),
+                         0);
+
+        if (!dimIdx) break;
+      }
+
+      permutPtr[i] = groupIndex;
+      ++groupsPtr[groupIndex].size;
+    }
+
+    // Compute the rolling sum, such that each group has its begin index
+    for (std::size_t i = 1; i < groups.size(); ++i) {
+      groupsPtr[i].begin += groupsPtr[i - 1].begin + groupsPtr[i - 1].size;
+    }
+
+    // Finally compute permutation index for each data point and restore group sizes.
+    for (std::size_t i = 0; i < n; ++i) {
+      permutPtr[i] = groupsPtr[permutPtr[i]].begin++;
+    }
+
+    // Restore begin index
+    for (std::size_t i = 0; i < groups.size(); ++i) {
+      groupsPtr[i].begin -= groupsPtr[i].size;
+    }
+
+    return DomainPartition(ctx, std::move(permut), std::move(groups));
+  }
+
+  inline auto groups() const -> const Buffer<Group>& { return groups_; }
+
+  inline auto num_elements() const -> std::size_t {
+    return std::visit(
+        [&](auto&& arg) -> std::size_t {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            return arg.size();
+          } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+            return arg;
+          }
+          return 0;
+        },
+        permut_);
+  }
+
+  template <typename F>
+  inline auto apply(const F* __restrict__ in, F* __restrict__ out) -> void {
+    std::visit(
+        [&](auto&& arg) {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            const auto* __restrict__ permutPtr = arg.get();
+            for (std::size_t i = 0; i < arg.size(); ++i) {
+              out[permutPtr[i]] = in[i];
+            }
+          } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+            std::memcpy(out, in, sizeof(F) * arg);
+          }
+        },
+        permut_);
+  }
+
+  template <typename F>
+  inline auto apply(F* __restrict__ inOut) -> void {
+    std::visit(
+        [&](auto&& arg) {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            const auto* __restrict__ permutPtr = arg.get();
+            Buffer<F> tmp(ctx_->host_alloc(), arg.size());
+            F* __restrict__ tmpPtr = tmp.get();
+            std::memcpy(tmpPtr, inOut, tmp.size_in_bytes());
+            for (std::size_t i = 0; i < arg.size(); ++i) {
+              inOut[permutPtr[i]] = tmpPtr[i];
+            }
+          }
+        },
+        permut_);
+  }
+
+  template <typename F>
+  inline auto reverse(const F* __restrict__ in, F* __restrict__ out) -> void {
+    std::visit(
+        [&](auto&& arg) {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            const auto* __restrict__ permutPtr = arg.get();
+            for (std::size_t i = 0; i < arg.size(); ++i) {
+              out[i] = in[permutPtr[i]];
+            }
+          } else if constexpr (std::is_same_v<ArgType, std::size_t>) {
+            std::memcpy(out, in, sizeof(F) * arg);
+          }
+        },
+        permut_);
+  }
+
+  template <typename F>
+  inline auto reverse(F* __restrict__ inOut) -> void {
+    std::visit(
+        [&](auto&& arg) {
+          using ArgType = std::decay_t<decltype(arg)>;
+          if constexpr (std::is_same_v<ArgType, Buffer<std::size_t>>) {
+            const auto* __restrict__ permutPtr = arg.get();
+            Buffer<F> tmp(ctx_->host_alloc(), arg.size());
+            F* __restrict__ tmpPtr = tmp.get();
+            for (std::size_t i = 0; i < arg.size(); ++i) {
+              tmpPtr[i] = inOut[permutPtr[i]];
+            }
+            std::memcpy(inOut, tmpPtr, tmp.size_in_bytes());
+          }
+        },
+        permut_);
+  }
+
+private:
+  explicit DomainPartition(std::shared_ptr<ContextInternal> ctx, Buffer<std::size_t> permut,
+                           Buffer<Group> groups)
+      : ctx_(std::move(ctx)), permut_(std::move(permut)), groups_(std::move(groups)) {}
+
+  explicit DomainPartition(std::shared_ptr<ContextInternal> ctx, std::size_t size,
+                           Buffer<Group> groups)
+      : ctx_(std::move(ctx)), permut_(size), groups_(std::move(groups)) {}
+
+  std::shared_ptr<ContextInternal> ctx_;
+  std::variant<std::size_t, Buffer<std::size_t>> permut_;
+  Buffer<Group> groups_;
+};
+
+}  // namespace host
+}  // namespace bipp

--- a/src/host/domain_partition.hpp
+++ b/src/host/domain_partition.hpp
@@ -37,8 +37,9 @@ public:
     std::array<T, DIM> minCoord, maxCoord;
 
     for (std::size_t dimIdx = 0; dimIdx < DIM; ++dimIdx) {
-      minCoord[dimIdx] = *std::min_element(coord[dimIdx], coord[dimIdx] + n);
-      maxCoord[dimIdx] = *std::max_element(coord[dimIdx], coord[dimIdx] + n);
+      auto minMaxIt = std::minmax_element(coord[dimIdx], coord[dimIdx] + n);
+      minCoord[dimIdx] = *minMaxIt.first;
+      maxCoord[dimIdx] = *minMaxIt.second;
     }
 
     Buffer<Group> groups(ctx->host_alloc(), gridSize);

--- a/src/host/nufft_synthesis.hpp
+++ b/src/host/nufft_synthesis.hpp
@@ -2,11 +2,14 @@
 
 #include <complex>
 #include <memory>
+#include <optional>
 
 #include "bipp/config.h"
 #include "bipp/exceptions.hpp"
+#include "bipp/nufft_synthesis.hpp"
 #include "context_internal.hpp"
 #include "memory/buffer.hpp"
+#include "host/domain_partition.hpp"
 
 namespace bipp {
 namespace host {
@@ -14,10 +17,10 @@ namespace host {
 template <typename T>
 class NufftSynthesis {
 public:
-  NufftSynthesis(std::shared_ptr<ContextInternal> ctx, T tol, std::size_t nAntenna,
-                 std::size_t nBeam, std::size_t nIntervals, std::size_t nFilter,
-                 const BippFilter* filter, std::size_t nPixel, const T* lmnX, const T* lmnY,
-                 const T* lmnZ);
+  NufftSynthesis(std::shared_ptr<ContextInternal> ctx, NufftSynthesisOptions opt,
+                 std::size_t nAntenna, std::size_t nBeam, std::size_t nIntervals,
+                 std::size_t nFilter, const BippFilter* filter, std::size_t nPixel, const T* lmnX,
+                 const T* lmnY, const T* lmnZ);
 
   auto collect(std::size_t nEig, T wl, const T* intervals, std::size_t ldIntervals,
                const std::complex<T>* s, std::size_t lds, const std::complex<T>* w, std::size_t ldw,
@@ -31,12 +34,13 @@ private:
   auto computeNufft() -> void;
 
   std::shared_ptr<ContextInternal> ctx_;
-  const T tol_;
+  NufftSynthesisOptions opt_;
   const std::size_t nIntervals_, nFilter_, nPixel_, nAntenna_, nBeam_;
   Buffer<BippFilter> filter_;
   Buffer<T> lmnX_, lmnY_, lmnZ_;
+  DomainPartition imgPartition_;
 
-  std::size_t nMaxInputCount_, inputCount_;
+  std::size_t nMaxInputCount_, collectCount_;
   Buffer<std::complex<T>> virtualVis_;
   Buffer<T> uvwX_, uvwY_, uvwZ_;
   Buffer<T> img_;

--- a/src/memory/buffer.hpp
+++ b/src/memory/buffer.hpp
@@ -48,6 +48,14 @@ public:
 
   inline auto data_handler() const noexcept -> const std::shared_ptr<void>& { return data_; }
 
+  inline auto begin() const -> const T* { return get(); }
+
+  inline auto begin() -> T* { return get(); }
+
+  inline auto end() const -> const T* { return get() + size_; }
+
+  inline auto end() -> T* { return get() + size_; }
+
 private:
   std::size_t size_;
   std::shared_ptr<void> data_;

--- a/src/nufft_util.hpp
+++ b/src/nufft_util.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
+#include "bipp/config.h"
+
+namespace bipp {
+inline auto optimal_nufft_input_partition(std::array<double, 3> inputExtent,
+                                          std::array<double, 3> outputExtent,
+                                          std::size_t maxFFTGridSize)
+    -> std::array<std::size_t, 3> {
+  constexpr double upsampfactor = 2.0;  // upsampling factor option used for finufft
+  constexpr double pi = 3.14159265358979323846;
+
+  std::size_t fftGridSize = 1;
+  for (std::size_t i = 0; i < inputExtent.size(); ++i) {
+    fftGridSize *=
+        static_cast<std::size_t>(2.0 * upsampfactor * inputExtent[i] * outputExtent[i] / pi);
+  }
+
+  const auto partitionSizeTarget = (fftGridSize + maxFFTGridSize - 1) / maxFFTGridSize;
+
+  std::array<std::size_t, 3> gridSize = {1, 1, 1};
+  std::array<double, 3> gridSpacing = inputExtent;
+  while (gridSize[0] * gridSize[1] * gridSize[2] < partitionSizeTarget) {
+    std::array<double, 3> sortedSpacing = gridSpacing;
+    std::sort(sortedSpacing.begin(), sortedSpacing.end());
+
+    const auto maxIndex =
+        std::max_element(gridSpacing.begin(), gridSpacing.end()) - gridSpacing.begin();
+
+    // Increase grid size at dimension with largest gridSpacing by multiplying with factor between
+    // largest and second largest grid spacing
+    gridSize[maxIndex] *= std::min(std::max<std::size_t>(2, sortedSpacing[2] / sortedSpacing[1]),
+                                   partitionSizeTarget);
+    gridSpacing[maxIndex] = inputExtent[maxIndex] / gridSize[maxIndex];
+  }
+
+  return gridSize;
+}
+}  // namespace bipp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(run_tests
   run_tests.cpp
   test_nufft_synthesis_lofar.cpp
   test_standard_synthesis_lofar.cpp
+  test_domain_partition.cpp
 )
 target_link_libraries(run_tests PRIVATE ${BIPP_TEST_LIBRARIES} bipp_test)
 target_compile_options(run_tests PRIVATE -DBIPP_TEST_DATA_DIR="${CMAKE_CURRENT_LIST_DIR}/data")

--- a/tests/test_domain_partition.cpp
+++ b/tests/test_domain_partition.cpp
@@ -1,0 +1,239 @@
+#include <array>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <tuple>
+#include <variant>
+#include <vector>
+
+#include "bipp/config.h"
+#include "context_internal.hpp"
+#include "gtest/gtest.h"
+#include "host/domain_partition.hpp"
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+#include "gpu/domain_partition.hpp"
+#include "gpu/util/runtime_api.hpp"
+#endif
+
+template <typename T>
+class DomainPartitionTest : public ::testing::TestWithParam<std::tuple<BippProcessingUnit>> {
+public:
+  using ValueType = T;
+
+  DomainPartitionTest() : ctx_(new bipp::ContextInternal(std::get<0>(GetParam()))) {}
+
+  auto test_grid(std::array<std::size_t, 3> gridDimensions, std::array<std::vector<T>, 3> domain) {
+    ASSERT_EQ(domain[0].size(), domain[1].size());
+    ASSERT_EQ(domain[0].size(), domain[2].size());
+
+    const auto gridSize = std::accumulate(gridDimensions.begin(), gridDimensions.end(),
+                                          std::size_t(1), std::multiplies<std::size_t>());
+
+    std::array<T, 3> minCoord, maxCoord, gridSpacing;
+
+    for (std::size_t dimIdx = 0; dimIdx < minCoord.size(); ++dimIdx) {
+      minCoord[dimIdx] = *std::min_element(domain[dimIdx].begin(), domain[dimIdx].end());
+      maxCoord[dimIdx] = *std::max_element(domain[dimIdx].begin(), domain[dimIdx].end());
+      gridSpacing[dimIdx] = (maxCoord[dimIdx] - minCoord[dimIdx]) / gridDimensions[dimIdx];
+    }
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+    std::variant<bipp::host::DomainPartition, bipp::gpu::DomainPartition> partition =
+        bipp::host::DomainPartition::none(ctx_, domain[0].size());
+#else
+    std::variant<bipp::host::DomainPartition> partition =
+        bipp::host::DomainPartition::none(ctx_, domain[0].size());
+#endif
+
+    if (ctx_->processing_unit() == BIPP_PU_GPU) {
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+      auto bufferX = ctx_->gpu_queue().create_device_buffer<T>(domain[0].size());
+      auto bufferY = ctx_->gpu_queue().create_device_buffer<T>(domain[0].size());
+      auto bufferZ = ctx_->gpu_queue().create_device_buffer<T>(domain[0].size());
+
+      bipp::gpu::api::memcpy_async(bufferX.get(), domain[0].data(), bufferX.size_in_bytes(),
+                                   bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+      bipp::gpu::api::memcpy_async(bufferY.get(), domain[1].data(), bufferY.size_in_bytes(),
+                                   bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+      bipp::gpu::api::memcpy_async(bufferZ.get(), domain[2].data(), bufferZ.size_in_bytes(),
+                                   bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+
+      partition = bipp::gpu::DomainPartition::grid<T>(
+          ctx_, gridDimensions, domain[0].size(), {bufferX.get(), bufferY.get(), bufferZ.get()});
+
+#else
+      ASSERT_TRUE(false);
+#endif
+    } else {
+      partition = bipp::host::DomainPartition::grid<T, 3>(
+          ctx_, gridDimensions, domain[0].size(),
+          {domain[0].data(), domain[1].data(), domain[2].data()});
+    }
+
+    std::visit(
+        [&](auto&& arg) -> void {
+          using variantType = std::decay_t<decltype(arg)>;
+          // Make sure groups cover all indices
+          std::vector<bool> inputCover(domain[0].size());
+          for (const auto& [begin, size] : arg.groups()) {
+            ASSERT_LE(begin + size, domain[0].size());
+            for (std::size_t i = begin; i < begin + size; ++i) {
+              inputCover[i] = true;
+            }
+          }
+          for (std::size_t i = 0; i < domain[0].size(); ++i) {
+            ASSERT_TRUE(inputCover[i]);
+          }
+
+          for (std::size_t dimIdx = 0; dimIdx < minCoord.size(); ++dimIdx) {
+            auto dataInPlace = domain[dimIdx];
+            auto dataOutOfPlace = std::vector<T>(dataInPlace.size());
+
+            // apply in place and out of place
+            if constexpr (std::is_same_v<variantType, bipp::host::DomainPartition>) {
+              arg.apply(dataInPlace.data(), dataOutOfPlace.data());
+              arg.apply(dataInPlace.data());
+            } else {
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+              auto dataInPlaceDevice =
+                  ctx_->gpu_queue().create_device_buffer<T>(dataInPlace.size());
+              auto dataOutOfPlaceDevice =
+                  ctx_->gpu_queue().create_device_buffer<T>(dataOutOfPlace.size());
+
+              bipp::gpu::api::memcpy_async(
+                  dataInPlaceDevice.get(), dataInPlace.data(), dataInPlaceDevice.size_in_bytes(),
+                  bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+
+              arg.apply(dataInPlaceDevice.get(), dataOutOfPlaceDevice.get());
+              arg.apply(dataInPlaceDevice.get());
+
+              bipp::gpu::api::memcpy_async(
+                  dataInPlace.data(), dataInPlaceDevice.get(), dataInPlaceDevice.size_in_bytes(),
+                  bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+              bipp::gpu::api::memcpy_async(dataOutOfPlace.data(), dataOutOfPlaceDevice.get(),
+                                           dataOutOfPlaceDevice.size_in_bytes(),
+                                           bipp::gpu::api::flag::MemcpyDefault,
+                                           ctx_->gpu_queue().stream());
+
+              ctx_->gpu_queue().sync();
+#endif
+            }
+
+            // check data
+            for (std::size_t i = 0; i < dataInPlace.size(); ++i) {
+              ASSERT_EQ(dataInPlace[i], dataOutOfPlace[i]);
+            }
+
+            for (const auto& [begin, size] : arg.groups()) {
+              if (size) {
+                auto minGroup = *std::min_element(dataInPlace.begin() + begin,
+                                                  dataInPlace.begin() + begin + size);
+                auto maxGroup = *std::max_element(dataInPlace.begin() + begin,
+                                                  dataInPlace.begin() + begin + size);
+
+                ASSERT_LE(maxGroup - minGroup, gridSpacing[dimIdx]);
+              }
+            }
+
+            // reverse in place and out of place
+            if constexpr (std::is_same_v<variantType, bipp::host::DomainPartition>) {
+              arg.reverse(dataInPlace.data(), dataOutOfPlace.data());
+              arg.reverse(dataInPlace.data());
+            } else {
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+              auto dataInPlaceDevice =
+                  ctx_->gpu_queue().create_device_buffer<T>(dataInPlace.size());
+              auto dataOutOfPlaceDevice =
+                  ctx_->gpu_queue().create_device_buffer<T>(dataOutOfPlace.size());
+
+              bipp::gpu::api::memcpy_async(
+                  dataInPlaceDevice.get(), dataInPlace.data(), dataInPlaceDevice.size_in_bytes(),
+                  bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+
+              arg.reverse(dataInPlaceDevice.get(), dataOutOfPlaceDevice.get());
+              arg.reverse(dataInPlaceDevice.get());
+
+              bipp::gpu::api::memcpy_async(
+                  dataInPlace.data(), dataInPlaceDevice.get(), dataInPlaceDevice.size_in_bytes(),
+                  bipp::gpu::api::flag::MemcpyDefault, ctx_->gpu_queue().stream());
+              bipp::gpu::api::memcpy_async(dataOutOfPlace.data(), dataOutOfPlaceDevice.get(),
+                                           dataOutOfPlaceDevice.size_in_bytes(),
+                                           bipp::gpu::api::flag::MemcpyDefault,
+                                           ctx_->gpu_queue().stream());
+
+              ctx_->gpu_queue().sync();
+#endif
+            }
+
+            // check reversed data
+            for (std::size_t i = 0; i < dataInPlace.size(); ++i) {
+              ASSERT_EQ(dataInPlace[i], dataOutOfPlace[i]);
+              ASSERT_EQ(dataInPlace[i], domain[dimIdx][i]);
+            }
+          }
+        },
+        partition);
+  }
+
+  std::shared_ptr<bipp::ContextInternal> ctx_;
+};
+
+using DomainPartitionSingle = DomainPartitionTest<float>;
+using DomainPartitionDouble = DomainPartitionTest<double>;
+
+template <typename T>
+static auto test_grid_random(std::size_t n, std::array<std::size_t, 3> gridDimensions,
+                             DomainPartitionTest<T>& t) -> void {
+  std::minstd_rand randGen(42);
+  std::uniform_real_distribution<T> distriX(-5.0, 10.0);
+  std::uniform_real_distribution<T> distriY(2.0, 20.0);
+  std::uniform_real_distribution<T> distriZ(100.0, 5000.0);
+
+  std::vector<T> x(n);
+  std::vector<T> y(n);
+  std::vector<T> z(n);
+
+  for (auto& val : x) val = distriX(randGen);
+  for (auto& val : y) val = distriY(randGen);
+  for (auto& val : z) val = distriZ(randGen);
+
+  t.test_grid(gridDimensions, {x, y, z});
+}
+
+TEST_P(DomainPartitionSingle, grid_n1) { test_grid_random(1, {2, 3, 4}, *this); }
+
+TEST_P(DomainPartitionDouble, grid_n1) { test_grid_random(1, {2, 3, 4}, *this); }
+
+TEST_P(DomainPartitionSingle, grid_n100) { test_grid_random(100, {2, 3, 4}, *this); }
+
+TEST_P(DomainPartitionDouble, grid_n100) { test_grid_random(100, {2, 3, 4}, *this); }
+
+TEST_P(DomainPartitionSingle, grid_n4000) { test_grid_random(4000, {2, 3, 4}, *this); }
+
+TEST_P(DomainPartitionDouble, grid_n4000) { test_grid_random(4000, {2, 3, 4}, *this); }
+
+static auto param_type_names(const ::testing::TestParamInfo<std::tuple<BippProcessingUnit>>& info)
+    -> std::string {
+  std::stringstream stream;
+
+  if (std::get<0>(info.param) == BIPP_PU_CPU)
+    stream << "CPU";
+  else
+    stream << "GPU";
+
+  return stream.str();
+}
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+#define TEST_PROCESSING_UNITS BIPP_PU_CPU, BIPP_PU_GPU
+#else
+#define TEST_PROCESSING_UNITS BIPP_PU_CPU
+#endif
+
+INSTANTIATE_TEST_SUITE_P(DomainPartition, DomainPartitionSingle,
+                         ::testing::Combine(::testing::Values(TEST_PROCESSING_UNITS)),
+                         param_type_names);
+
+INSTANTIATE_TEST_SUITE_P(Lofar, DomainPartitionDouble,
+                         ::testing::Combine(::testing::Values(TEST_PROCESSING_UNITS)),
+                         param_type_names);

--- a/tests/test_nufft_synthesis_lofar.cpp
+++ b/tests/test_nufft_synthesis_lofar.cpp
@@ -104,8 +104,8 @@ protected:
     const auto lmnZ = read_json_scalar_1d<T>(output_data["lmn_z"]);
     const std::size_t nPixel = imgRef.size() / nIntervals;
 
-    bipp::NufftSynthesis<T> imager(ctx_, tol, nAntenna, nBeam, nIntervals, 1, &filter, nPixel,
-                                   lmnX.data(), lmnY.data(), lmnZ.data());
+    bipp::NufftSynthesis<T> imager(ctx_, bipp::NufftSynthesisOptions(), nAntenna, nBeam, nIntervals,
+                                   1, &filter, nPixel, lmnX.data(), lmnY.data(), lmnZ.data());
 
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);
@@ -145,8 +145,8 @@ protected:
     const auto lmnZ = read_json_scalar_1d<T>(output_data["lmn_z"]);
     const std::size_t nPixel = imgRef.size() / nIntervals;
 
-    bipp::NufftSynthesis<T> imager(ctx_, tol, nAntenna, nBeam, nIntervals, 1, &filter, nPixel,
-                                   lmnX.data(), lmnY.data(), lmnZ.data());
+    bipp::NufftSynthesis<T> imager(ctx_, bipp::NufftSynthesisOptions(), nAntenna, nBeam, nIntervals,
+                                   1, &filter, nPixel, lmnX.data(), lmnY.data(), lmnZ.data());
 
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);


### PR DESCRIPTION
This PR includes:
- Domain partitioning of the image and uvw domain when using NUFFT Synthesis
- Introduction of `NufftSynthesisOptions` which provides a unified way for settings options like the partitioning method. It provides default settings that can be selectively changed. 

This introduces a braking change to the NUFFT Synthesis API, so external CI would need to be adjusted.
