### PR TITLE
Add logging functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CUDA_STANDARD_REQUIRED ON)
 include(GNUInstallDirs)
 
 include(FetchContent)
+include(CMakeDependentOption)
 
 #add local module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules)
@@ -52,11 +53,15 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules)
 option(BIPP_BUILD_TESTS "Build tests" OFF)
 option(BIPP_PYTHON "Build python module" ON)
 option(BIPP_MAGMA "Use MAGMA library as eigensolver" OFF)
-option(BIPP_PYBIND11_DOWNLOAD "Download pybind11 instead of looking for installation" OFF)
 option(BIPP_UMPIRE "Use Umpire memory pool library" OFF)
 option(BIPP_VC "Use VC vectorization library" OFF)
 option(BIPP_OMP "Use OpenMP for multi-threading" ON)
 option(BIPP_BUNDLED_LIBS "Use bundled libraries for spdlog, googletest and json" ON)
+
+cmake_dependent_option(BIPP_BUNDLED_SPDLOG "Use bundled spdlog lib" ON "BIPP_BUNDLED_LIBS" OFF)
+cmake_dependent_option(BIPP_BUNDLED_PYBIND11 "Use bundled pybind11 lib" ON "BIPP_BUNDLED_LIBS" OFF)
+cmake_dependent_option(BIPP_BUNDLED_GOOGLETEST "Use bundled googletest lib" ON "BIPP_BUNDLED_LIBS" OFF)
+cmake_dependent_option(BIPP_BUNDLED_JSON "Use bundled json lib" ON "BIPP_BUNDLED_LIBS" OFF)
 
 set(BIPP_GPU "OFF" CACHE STRING "GPU backend")
 set_property(CACHE BIPP_GPU PROPERTY STRINGS
@@ -214,7 +219,7 @@ if(BIPP_VC)
 endif()
 
 
-if(BIPP_BUNDLED_LIBS)
+if(BIPP_BUNDLED_SPDLOG)
   FetchContent_Declare(
 	spdlog
 	URL https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if(POLICY CMP0022)
 	cmake_policy(SET CMP0022 NEW)
 endif()
 
+# update time stamps when using FetchContent
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+endif()
+
 # set default build type to RELEASE
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
@@ -38,6 +43,8 @@ set(CUDA_STANDARD_REQUIRED ON)
 # Get GNU standard install prefixes
 include(GNUInstallDirs)
 
+include(FetchContent)
+
 #add local module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake/modules)
 
@@ -49,6 +56,7 @@ option(BIPP_PYBIND11_DOWNLOAD "Download pybind11 instead of looking for installa
 option(BIPP_UMPIRE "Use Umpire memory pool library" OFF)
 option(BIPP_VC "Use VC vectorization library" OFF)
 option(BIPP_OMP "Use OpenMP for multi-threading" ON)
+option(BIPP_BUNDLED_LIBS "Use bundled libraries for spdlog, googletest and json" ON)
 
 set(BIPP_GPU "OFF" CACHE STRING "GPU backend")
 set_property(CACHE BIPP_GPU PROPERTY STRINGS
@@ -203,6 +211,23 @@ endif()
 if(BIPP_VC)
   find_package(Vc CONFIG REQUIRED)
   list(APPEND BIPP_EXTERNAL_LIBS Vc::Vc)
+endif()
+
+
+if(BIPP_BUNDLED_LIBS)
+  FetchContent_Declare(
+	spdlog
+	URL https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.tar.gz
+	URL_MD5 287c6492c25044fd2da9947ab120b2bd
+  )
+  FetchContent_GetProperties(spdlog)
+  if(NOT spdlog_POPULATED)
+	FetchContent_Populate(spdlog)
+  endif()
+  list(APPEND BIPP_INCLUDE_DIRS ${spdlog_SOURCE_DIR}/include)
+else()
+  find_package(spdlog CONFIG REQUIRED)
+  list(APPEND BIPP_EXTERNAL_LIBS spdlog::spdlog)
 endif()
 
 # check if C api is available for blas and lapack

--- a/README.md
+++ b/README.md
@@ -39,17 +39,17 @@ Bipp uses CMake to configure the build.
 
 ### CMake options
 Bipp can be configured with the following options:
-| Option                   |  Values                   | Default | Description                                                   |
-|--------------------------|---------------------------|---------|---------------------------------------------------------------|
-| `BIPP_PYTHON`            |  `ON`, `OFF`              | `ON`    | Build Python interface                                        |
-| `BIPP_OMP`               |  `ON`, `OFF`              | `ON`    | Enable multi-threading with OpenMP                            |
-| `BIPP_VC`                |  `ON`, `OFF`              | `OFF`   | Use the VC library for vectorization                          |
-| `BIPP_GPU`               |  `OFF`, `CUDA`, `ROCM`    | `OFF`   | Select GPU backend                                            |
-| `BIPP_MAGMA`             |  `ON`, `OFF`              | `OFF`   | Use MAGMA as eigensolver on GPU                               |
-| `BIPP_BUILD_TESTS`       |  `ON`, `OFF`              | `OFF`   | Build test executables                                        |
-| `BIPP_INSTALL`           |  `LIB`, `PYTHON`, `OFF`   | `LIB`   | Set installation target                                       |
-| `BIPP_UMPIRE`            |  `ON`, `OFF`              | `OFF`   | Use the UMPIRE library for memory allocations                 |
-| `BIPP_PYBIND11_DOWNLOAD` |  `ON`, `OFF`              | `OFF`   | Download pybind11 instead of using external installation      |
+| Option                   |  Values                   | Default | Description                                                             |
+|--------------------------|---------------------------|---------|-------------------------------------------------------------------------|
+| `BIPP_PYTHON`            |  `ON`, `OFF`              | `ON`    | Build Python interface                                                  |
+| `BIPP_OMP`               |  `ON`, `OFF`              | `ON`    | Enable multi-threading with OpenMP                                      |
+| `BIPP_VC`                |  `ON`, `OFF`              | `OFF`   | Use the VC library for vectorization                                    |
+| `BIPP_GPU`               |  `OFF`, `CUDA`, `ROCM`    | `OFF`   | Select GPU backend                                                      |
+| `BIPP_MAGMA`             |  `ON`, `OFF`              | `OFF`   | Use MAGMA as eigensolver on GPU                                         |
+| `BIPP_BUILD_TESTS`       |  `ON`, `OFF`              | `OFF`   | Build test executables                                                  |
+| `BIPP_INSTALL`           |  `LIB`, `PYTHON`, `OFF`   | `LIB`   | Set installation target                                                 |
+| `BIPP_UMPIRE`            |  `ON`, `OFF`              | `OFF`   | Use the UMPIRE library for memory allocations                           |
+| `BIPP_BUNDLED_LIBS`      |  `ON`, `OFF`              | `ON`    | Download and build spdlog, pybind11, googletest and json library.       |
 
 
 Some useful general CMake options are:

--- a/cmake/bippStaticConfig.cmake
+++ b/cmake/bippStaticConfig.cmake
@@ -12,17 +12,18 @@ set(_CMAKE_MODULE_PATH_SAVE ${CMAKE_MODULE_PATH})
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 
 # options used for building library
-set(bipp_GPU @bipp_GPU@)
-set(bipp_CUDA @bipp_CUDA@)
-set(bipp_ROCM @bipp_ROCM@)
+set(BIPP_GPU @BIPP_GPU@)
+set(BIPP_CUDA @BIPP_CUDA@)
+set(BIPP_ROCM @BIPP_ROCM@)
+set(BIPP_BUNDLED_SPDLOG @BIPP_BUNDLED_SPDLOG@)
 
-if(bipp_ROCM)
+if(BIPP_ROCM)
 	find_dependency(hip CONFIG)
 	find_dependency(rocblas CONFIG)
 endif()
 
 
-if(bipp_CUDA)
+if(BIPP_CUDA)
 	if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0") 
 		find_dependency(CUDAToolkit)
 	else()
@@ -48,6 +49,10 @@ if(NOT TARGET BLAS::blas)
 	# target is only available with CMake 3.18.0 and later
 	add_library(BLAS::blas INTERFACE IMPORTED)
 	set_property(TARGET BLAS::blas PROPERTY INTERFACE_LINK_LIBRARIES ${BLAS_LIBRARIES} ${BLAS_LINKER_FLAGS})
+endif()
+
+if(NOT BIPP_BUNDLED_SPDLOG)
+	find_dependency(spdlog CONFIG)
 endif()
 
 set(CMAKE_MODULE_PATH ${_CMAKE_MODULE_PATH_SAVE}) # restore module path

--- a/include/bipp/enums.h
+++ b/include/bipp/enums.h
@@ -12,10 +12,19 @@ enum BippFilter {
   BIPP_FILTER_INV_SQ
 };
 
+enum BippLogLevel {
+  BIPP_LOG_LEVEL_OFF,
+  BIPP_LOG_LEVEL_ERROR,
+  BIPP_LOG_LEVEL_WARN,
+  BIPP_LOG_LEVEL_INFO,
+  BIPP_LOG_LEVEL_DEBUG,
+};
+
 #ifndef __cplusplus
 /*! \cond PRIVATE */
 // C only
 typedef enum BippProcessingUnit BippProcessingUnit;
 typedef enum BippFilter BippFilter;
+typedef enum BippLogLevel BippLogLevel;
 /*! \endcond */
 #endif  // cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,12 +1,11 @@
 set(Python_FIND_FRAMEWORK LAST) # Prefer Brew/Conda to Apple framework python
 find_package(Python 3.6 COMPONENTS Interpreter Development REQUIRED)
 
-if (BIPP_PYBIND11_DOWNLOAD)
-	include(FetchContent)
+if (BIPP_BUNDLED_PYBIND11)
 	FetchContent_Declare(
 		pybind11
-		GIT_REPOSITORY https://github.com/pybind/pybind11.git
-		GIT_TAG        v2.9.2
+		URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.4.tar.gz
+		URL_MD5 812eda11d2a114fc0e841faf9626d2c9
 	)
 	FetchContent_MakeAvailable(pybind11)
 else()

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "-DBIPP_OMP=" + bipp_omp,
         "-DBIPP_VC=" + bipp_vc,
         "-DBIPP_MAGMA=" + bipp_magma,
+        "-DBIPP_BUNDLED_LIBS=ON",
         "-DBUILD_SHARED_LIBS=ON",
         "-DBIPP_INSTALL=PIP",
     ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(BIPP_SOURCE_FILES
 	standard_synthesis.cpp
 	context.cpp
 	nufft_synthesis.cpp
+	logger.cpp
 	memory/allocator_factory.cpp
 	host/eigensolver.cpp
 	host/gram_matrix.cpp

--- a/src/context_internal.hpp
+++ b/src/context_internal.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
+#include <cstring>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "bipp/bipp.h"
 #include "bipp/config.h"
 #include "bipp/context.hpp"
 #include "bipp/exceptions.hpp"
+#include "logger.hpp"
 #include "memory/allocator.hpp"
 #include "memory/allocator_factory.hpp"
 
@@ -23,7 +26,8 @@ namespace bipp {
 
 class ContextInternal {
 public:
-  explicit ContextInternal(BippProcessingUnit pu) : hostAlloc_(AllocatorFactory::host()) {
+  explicit ContextInternal(BippProcessingUnit pu)
+      : hostAlloc_(AllocatorFactory::host()), log_(BIPP_LOG_LEVEL_OFF) {
     if (pu == BIPP_PU_AUTO) {
       // select GPU if available
 #if defined(BIPP_CUDA) || defined(BIPP_ROCM)
@@ -44,6 +48,31 @@ public:
 #if defined(BIPP_CUDA) || defined(BIPP_ROCM)
     if (pu_ == BIPP_PU_GPU) queue_.emplace();
 #endif
+
+    const char* logOut = "stdout";
+    if(const char* logOutEnv = std::getenv("BIPP_LOG_OUT")) {
+      logOut = logOutEnv;
+    }
+
+
+    // Set initial log level if environment variable is set
+    if(const char* envLog = std::getenv("BIPP_LOG_LEVEL")) {
+      if (!std::strcmp(envLog, "off") || !std::strcmp(envLog, "OFF"))
+        log_ = Logger(BIPP_LOG_LEVEL_OFF, logOut);
+      else if (!std::strcmp(envLog, "debug") || !std::strcmp(envLog, "DEBUG"))
+        log_ = Logger(BIPP_LOG_LEVEL_DEBUG, logOut);
+      else if (!std::strcmp(envLog, "info") || !std::strcmp(envLog, "INFO"))
+        log_ = Logger(BIPP_LOG_LEVEL_INFO, logOut);
+      else if (!std::strcmp(envLog, "warn") || !std::strcmp(envLog, "WARN"))
+        log_ = Logger(BIPP_LOG_LEVEL_WARN, logOut);
+      else if (!std::strcmp(envLog, "error") || !std::strcmp(envLog, "ERROR"))
+        log_ = Logger(BIPP_LOG_LEVEL_ERROR, logOut);
+    }
+
+    if(pu_== BIPP_PU_CPU)
+      log_.log(BIPP_LOG_LEVEL_INFO, "{} CPU context created", static_cast<const void*>(this));
+    else
+      log_.log(BIPP_LOG_LEVEL_INFO, "{} GPU context created", static_cast<const void*>(this));
   }
 
 #if defined(BIPP_CUDA) || defined(BIPP_ROCM)
@@ -56,8 +85,20 @@ public:
 
   auto host_alloc() const -> const std::shared_ptr<Allocator>& { return hostAlloc_; }
 
+  auto set_log(BippLogLevel level, const char* out = "stdout") { log_ = Logger(level, out); }
+
+  auto logger() -> Logger& { return log_; }
+
+  ~ContextInternal() {
+    try {
+      log_.log(BIPP_LOG_LEVEL_INFO, "{} Context destroyed", static_cast<const void*>(this));
+    } catch (...) {
+    }
+  }
+
 private:
   BippProcessingUnit pu_;
+  Logger log_;
   std::shared_ptr<Allocator> hostAlloc_;
 
 #if defined(BIPP_CUDA) || defined(BIPP_ROCM)

--- a/src/gpu/eigensolver.cpp
+++ b/src/gpu/eigensolver.cpp
@@ -37,6 +37,8 @@ auto eigh(ContextInternal& ctx, std::size_t m, std::size_t nEig, const api::Comp
   eigensolver::solve(ctx, 'V', 'V', 'L', m, aBuffer.get(), m, std::numeric_limits<T>::epsilon(),
                      std::numeric_limits<T>::max(), 1, m, &hMeig, dBuffer.get());
 
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "eigenvalues", hMeig, 1, dBuffer.get(), hMeig);
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "eigenvectors", m, m, aBuffer.get(), m);
   if (b) {
     auto bBuffer = queue.create_device_buffer<ComplexType>(m * m);  // Matrix B
     api::memcpy_2d_async(bBuffer.get(), m * sizeof(ComplexType), b, ldb * sizeof(ComplexType),
@@ -73,6 +75,9 @@ auto eigh(ContextInternal& ctx, std::size_t m, std::size_t nEig, const api::Comp
     eigensolver::solve(ctx, 'V', 'V', 'L', m, aBuffer.get(), m, bBuffer.get(), m,
                        std::numeric_limits<T>::epsilon(), std::numeric_limits<T>::max(), 1, m,
                        &hMeig, dBuffer.get());
+    ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gen. eigenvalues", hMeig, 1, dBuffer.get(),
+                            hMeig);
+    ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gen. eigenvectors", m, m, aBuffer.get(), m);
   }
 
   if (hMeig > 1) {

--- a/src/gpu/gram_matrix.cpp
+++ b/src/gpu/gram_matrix.cpp
@@ -49,6 +49,8 @@ auto gram_matrix(ContextInternal& ctx, std::size_t m, std::size_t n, const api::
 
   api::memcpy_2d_async(g, ldg * sizeof(ComplexType), gD.get(), n * sizeof(ComplexType),
                        n * sizeof(ComplexType), n, api::flag::MemcpyDefault, queue.stream());
+
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gram", n, n, g, ldg);
 }
 
 template auto gram_matrix<float>(ContextInternal& ctx, std::size_t m, std::size_t n,

--- a/src/gpu/nufft_synthesis.cpp
+++ b/src/gpu/nufft_synthesis.cpp
@@ -42,8 +42,13 @@ NufftSynthesis<T>::NufftSynthesis(std::shared_ptr<ContextInternal> ctx, NufftSyn
       [&](auto&& arg) -> void {
         using ArgType = std::decay_t<decltype(arg)>;
         if constexpr (std::is_same_v<ArgType, Partition::Grid>) {
+          ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "image partition: grid ({}, {}, {})",
+                             arg.dimensions[0], arg.dimensions[1], arg.dimensions[2]);
           imgPartition_ =
               DomainPartition::grid<T>(ctx_, arg.dimensions, nPixel_, {lmnX, lmnY, lmnZ});
+        } else if constexpr (std::is_same_v<ArgType, Partition::None> ||
+                             std::is_same_v<ArgType, Partition::Auto>) {
+          ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "image partition: none");
         }
       },
       opt_.localImagePartition.method);
@@ -121,6 +126,7 @@ auto NufftSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals, std:
               nMaxInputCount_ * nAntenna_ * nAntenna_, nAntenna_);
 
   ++collectCount_;
+  ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "collect count: {} / {}", collectCount_, nMaxInputCount_);
   if (collectCount_ >= nMaxInputCount_) {
     computeNufft();
   }
@@ -140,10 +146,13 @@ auto NufftSynthesis<T>::computeNufft() -> void {
         [&](auto&& arg) -> DomainPartition {
           using ArgType = std::decay_t<decltype(arg)>;
           if constexpr (std::is_same_v<ArgType, Partition::Grid>) {
+            ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "uvw partition: grid ({}, {}, {})",
+                               arg.dimensions[0], arg.dimensions[1], arg.dimensions[2]);
             return DomainPartition::grid<T>(ctx_, arg.dimensions, nInputPoints,
                                             {uvwX_.get(), uvwY_.get(), uvwZ_.get()});
 
           } else if constexpr (std::is_same_v<ArgType, Partition::None>) {
+            ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "uvw partition: none");
             return DomainPartition::none(ctx_, nInputPoints);
 
           } else if constexpr (std::is_same_v<ArgType, Partition::Auto>) {
@@ -188,6 +197,9 @@ auto NufftSynthesis<T>::computeNufft() -> void {
                 uvwExtent, imgExtent,
                 queue.device_prop().totalGlobalMem / (4 * sizeof(api::ComplexType<T>)));
 
+            ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "uvw partition: grid ({}, {}, {})", gridSize[0],
+                               gridSize[1], gridSize[2]);
+
             // set partition method to grid and create grid partition
             opt_.localUVWPartition.method = Partition::Grid{gridSize};
             return DomainPartition::grid<T>(ctx_, gridSize, nInputPoints,
@@ -225,8 +237,13 @@ auto NufftSynthesis<T>::computeNufft() -> void {
         for (std::size_t i = 0; i < nFilter_; ++i) {
           for (std::size_t j = 0; j < nIntervals_; ++j) {
             auto imgPtr = img_.get() + (j + i * nIntervals_) * nPixel_ + imgBegin;
+            ctx_->logger().log_matrix(
+                BIPP_LOG_LEVEL_DEBUG, "NUFFT input", inputSize, 1,
+                virtualVis_.get() + i * ldVirtVis1 + j * ldVirtVis2 + inputBegin, inputSize);
             transform.execute(virtualVis_.get() + i * ldVirtVis1 + j * ldVirtVis2 + inputBegin,
                               outputPtr);
+            ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "NUFFT output", imgSize, 1, outputPtr,
+                                      imgSize);
 
             // add dependency on default stream for correct ordering
             queue.sync_with_stream(nullptr);
@@ -258,16 +275,24 @@ auto NufftSynthesis<T>::get(BippFilter f, T* outHostOrDevice, std::size_t ld) ->
 
   if (is_device_ptr(outHostOrDevice)) {
     for (std::size_t i = 0; i < nIntervals_; ++i) {
+      ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "image permuted", nPixel_, 1,
+                                img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_, nPixel_);
       imgPartition_.reverse(img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_,
                             outHostOrDevice + i * ld);
+      ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "image output", nPixel_, 1,
+                                outHostOrDevice + i * ld, nPixel_);
     }
   } else {
     auto workBuffer = queue.create_device_buffer<T>(nPixel_);
     for (std::size_t i = 0; i < nIntervals_; ++i) {
+      ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "image permuted", nPixel_, 1,
+                                img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_, nPixel_);
       imgPartition_.reverse(img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_,
                             workBuffer.get());
       gpu::api::memcpy_async(outHostOrDevice + i * ld, workBuffer.get(), workBuffer.size_in_bytes(),
                              gpu::api::flag::MemcpyDefault, queue.stream());
+      ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "image output", nPixel_, 1,
+                                outHostOrDevice + i * ld, nPixel_);
     }
   }
 }

--- a/src/gpu/virtual_vis.cpp
+++ b/src/gpu/virtual_vis.cpp
@@ -64,6 +64,12 @@ auto virtual_vis(ContextInternal& ctx, std::size_t nFilter, const BippFilter* fi
         scale_matrix<T>(queue, nAntenna, size, V + start * ldv, ldv, DFilteredBuffer.get() + start,
                         VMulDBuffer.get(), nAntenna);
 
+        for (std::size_t k = 0; k < size; ++k) {
+          ctx.logger().log(BIPP_LOG_LEVEL_DEBUG, "Assigning eigenvalue {} to inverval [{}, {}]",
+                           *(DBufferHost.get() + start + k), intervalsHost[j * ldIntervals],
+                           intervalsHost[j * ldIntervals + 1]);
+        }
+
         // Matrix multiplication of the previously scaled V and the original V
         // with the selected eigenvalues
         api::blas::gemm(queue.blas_handle(), api::blas::operation::None,

--- a/src/host/eigensolver.cpp
+++ b/src/host/eigensolver.cpp
@@ -51,6 +51,8 @@ auto eigh(ContextInternal& ctx, std::size_t m, std::size_t nEig, const std::comp
                          &hMeig, bufferD.get(), bufferV.get(), m, bufferIfail.get())) {
     throw EigensolverError();
   }
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "eigenvalues", hMeig, 1, bufferD.get(), hMeig);
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "eigenvectors", m, m, bufferV.get(), m);
 
   if (b) {
     if (static_cast<std::size_t>(hMeig) != m) {
@@ -84,6 +86,8 @@ auto eigh(ContextInternal& ctx, std::size_t m, std::size_t nEig, const std::comp
                            bufferV.get(), m, bufferIfail.get())) {
       throw EigensolverError();
     }
+    ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gen. eigenvalues", hMeig, 1, bufferD.get(), hMeig);
+    ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gen. eigenvectors", m, m, bufferV.get(), m);
   }
 
   // reorder into descending order. At most nEig eigenvalues / eigenvectors.

--- a/src/host/gram_matrix.cpp
+++ b/src/host/gram_matrix.cpp
@@ -52,6 +52,8 @@ auto gram_matrix(ContextInternal& ctx, std::size_t m, std::size_t n, const std::
              bufferC.get(), m);
   blas::gemm(CblasColMajor, CblasConjTrans, CblasNoTrans, n, n, m, {1, 0}, w, ldw, bufferC.get(), m,
              {0, 0}, g, ldg);
+
+  ctx.logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gram", n, n, g, ldg);
 }
 
 template auto gram_matrix<float>(ContextInternal& ctx, std::size_t m, std::size_t n,

--- a/src/host/standard_synthesis.cpp
+++ b/src/host/standard_synthesis.cpp
@@ -96,6 +96,8 @@ auto StandardSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals,
 
   gemmexp(nEig, nPixel_, nAntenna_, alpha, vUnbeam.get(), nAntenna_, xyzCentered.get(), nAntenna_,
           pixelX_.get(), pixelY_.get(), pixelZ_.get(), unlayeredStats.get(), nPixel_);
+  ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "gemmexp", nPixel_, nEig, unlayeredStats.get(),
+                            nPixel_);
 
   // cluster eigenvalues / vectors based on invervals
   for (std::size_t idxFilter = 0; idxFilter < nFilter_; ++idxFilter) {
@@ -111,6 +113,11 @@ auto StandardSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals,
         auto unlayeredStatsCurrent = unlayeredStats.get() + nPixel_ * idxEig;
 
         constexpr auto maxInt = static_cast<std::size_t>(std::numeric_limits<int>::max());
+
+        ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG,
+                           "Assigning eigenvalue {} (filtered {}) to inverval [{}, {}]",
+                           *(d.get() + idxEig), scale, intervals[idxInt * ldIntervals],
+                           intervals[idxInt * ldIntervals + 1]);
 
         for (std::size_t idxPix = 0; idxPix < nPixel_; idxPix += maxInt) {
           const auto nPixBlock = std::min(nPixel_ - idxPix, maxInt);
@@ -136,6 +143,8 @@ auto StandardSynthesis<T>::get(BippFilter f, T* out, std::size_t ld) -> void {
   for (std::size_t i = 0; i < nIntervals_; ++i) {
     std::memcpy(out + i * ld, img_.get() + index * nIntervals_ * nPixel_ + i * nPixel_,
                 sizeof(T) * nPixel_);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "image output", nPixel_, 1, out + i * ld,
+                              nPixel_);
   }
 }
 

--- a/src/host/virtual_vis.cpp
+++ b/src/host/virtual_vis.cpp
@@ -52,6 +52,10 @@ auto virtual_vis(ContextInternal& ctx, std::size_t nFilter, const BippFilter* fi
           auto VMulD = VMulDBuffer.get() + k * nAntenna;
           const auto VSelect = V + (start + k) * ldv;
           const auto DVal = DFiltered[start + k];
+
+          ctx.logger().log(
+              BIPP_LOG_LEVEL_DEBUG, "Assigning eigenvalue {} (filtered {}) to inverval [{}, {}]",
+              D[start + k], DVal, intervals[j * ldIntervals], intervals[j * ldIntervals + 1]);
           for (std::size_t l = 0; l < nAntenna; ++l) {
             VMulD[l] = VSelect[l] * DVal;
           }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,200 @@
+#include "logger.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <spdlog/common.h>
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/spdlog.h>
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+#include "gpu/util/device_pointer.hpp"
+#include "gpu/util/runtime_api.hpp"
+#endif
+
+namespace bipp {
+namespace {
+
+template<typename T>
+struct ArrayInfo {
+  ArrayInfo(std::size_t m, std::size_t n, const T* array, std::size_t ld)
+      : m(m), n(n), sum(0), normal(false), subnormal(false), inf(false), nan(false), zero(false) {
+    std::vector<T> buffer;
+    const T* data = array;
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+    if (gpu::is_device_ptr(array)) {
+      buffer.resize(m * n);
+      gpu::api::device_synchronize();
+      gpu::api::memcpy_2d(buffer.data(), m * sizeof(T), array, ld * sizeof(T), m * sizeof(T), n,
+                          gpu::api::flag::MemcpyDefault);
+
+      data = buffer.data();
+      ld = m;
+    }
+#endif
+
+    if constexpr (std::is_same_v<T, std::complex<float>> ||
+                  std::is_same_v<T, std::complex<double>>) {
+      min = T{std::numeric_limits<typename T::value_type>::max(),
+              std::numeric_limits<typename T::value_type>::max()};
+      max = T{-std::numeric_limits<typename T::value_type>::max(),
+              -std::numeric_limits<typename T::value_type>::max()};
+
+      for(std::size_t c = 0; c < n; ++c) {
+        for (std::size_t r = 0; r < m; ++r) {
+          const auto& val = data[c * ld + r];
+          min = T{std::min(min.real(), val.real()), std::min(min.imag(), val.imag())};
+          max = T{std::max(max.real(), val.real()), std::max(max.imag(), val.imag())};
+
+          sum += val;
+
+          const auto fpReal = std::fpclassify(val.real());
+          const auto fpImag = std::fpclassify(val.imag());
+
+          normal |= (fpReal == FP_NORMAL) | (fpImag == FP_NORMAL);
+          subnormal |= (fpReal == FP_SUBNORMAL) | (fpImag == FP_SUBNORMAL);
+          inf |= (fpReal == FP_INFINITE) | (fpImag == FP_INFINITE);
+          nan |= (fpReal == FP_NAN) | (fpImag == FP_NAN);
+          zero |= (fpReal == FP_ZERO) | (fpImag == FP_ZERO);
+        }
+      }
+    } else {
+      min = std::numeric_limits<T>::max();
+      max = -std::numeric_limits<T>::max();
+
+      for(std::size_t c = 0; c < n; ++c) {
+        for (std::size_t r = 0; r < m; ++r) {
+          const auto& val = data[c * ld + r];
+          min = std::min(min, val);
+          max = std::max(max, val);
+
+          sum += val;
+
+          const auto fp = std::fpclassify(val);
+
+          normal |= (fp == FP_NORMAL);
+          subnormal |= (fp == FP_SUBNORMAL);
+          inf |= (fp == FP_INFINITE);
+          nan |= (fp == FP_NAN);
+        }
+      }
+
+    }
+  }
+
+  std::size_t m, n;
+  T min, max, sum;
+  bool normal, subnormal, inf, nan, zero;
+};
+
+template <typename T>
+auto log_array(spdlog::level::level_enum lvl, spdlog::logger& log, const std::string_view& s,
+               std::size_t m, std::size_t n, const T* array, std::size_t ld) -> void {
+
+  std::string logString;
+
+  logString += "array \"" + std::string(s) + "\": ";
+
+  if(m == 0 || n == 0) {
+    logString += " size ({}, {})";
+    log.log(lvl, logString, m, n);
+    return;
+  }
+
+  if constexpr (std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+    logString += " size ({}, {}), min ({}, {}), max ({}, {}), sum ({}, {})";
+  } else {
+    logString += " size ({}, {}), min {}, max {}, sum {}";
+  }
+
+  ArrayInfo<T> info(m, n, array, ld);
+
+  logString += ", fp classes [";
+
+  if(info.normal) logString += "normal,";
+  if (info.zero) logString += "zero,";
+  if (info.subnormal) logString += "subnormal,";
+  if (info.inf) logString += "inf,";
+  if (info.nan) logString += "nan,";
+
+  if(logString.back() == ',') logString.pop_back();
+  logString += "]";
+
+  if constexpr (std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>) {
+    log.log(lvl, logString, info.m, info.n, info.min.real(), info.min.imag(),
+            info.max.real(), info.max.imag(), info.sum.real(), info.sum.imag());
+  } else {
+    log.log(lvl,  logString, info.m, info.n, info.min, info.max, info.sum);
+  }
+}
+
+}  // namespace
+
+
+Logger::Logger(BippLogLevel level, const char* out) : level_(level) {
+  spdlog::set_automatic_registration(false);
+  if (!std::strcmp(out, "stdout")) {
+      logger_ = spdlog::stdout_logger_st("bipp");
+  } else if (!std::strcmp(out, "stderr")) {
+      logger_ = spdlog::stderr_logger_st("bipp");
+  } else {
+      try {
+      logger_ = spdlog::basic_logger_st("bipp", out, false);
+      } catch (const spdlog::spdlog_ex& ex) {
+      logger_ = spdlog::stderr_logger_st("bipp");
+      }
+  }
+  logger_->set_level(convert_level(level));
+}
+
+auto Logger::convert_level(BippLogLevel l) -> spdlog::level::level_enum {
+  switch (l) {
+    case BippLogLevel::BIPP_LOG_LEVEL_OFF:
+      return spdlog::level::off;
+    case BippLogLevel::BIPP_LOG_LEVEL_ERROR:
+      return spdlog::level::err;
+    case BippLogLevel::BIPP_LOG_LEVEL_WARN:
+      return spdlog::level::warn;
+    case BippLogLevel::BIPP_LOG_LEVEL_INFO:
+      return spdlog::level::info;
+    case BippLogLevel::BIPP_LOG_LEVEL_DEBUG:
+      return spdlog::level::debug;
+  }
+
+  return spdlog::level::debug;
+}
+
+auto Logger::log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const float* array, std::size_t ld) -> void {
+  if (level <= level_) {
+      log_array(convert_level(level), *logger_, s, m, n, array, ld);
+  }
+}
+auto Logger::log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const double* array, std::size_t ld) -> void {
+  if (level <= level_) {
+      log_array(convert_level(level), *logger_, s, m, n, array, ld);
+  }
+}
+auto Logger::log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const std::complex<float>* array, std::size_t ld) -> void {
+  if (level <= level_) {
+      log_array(convert_level(level), *logger_, s, m, n, array, ld);
+  }
+}
+auto Logger::log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                        const std::complex<double>* array, std::size_t ld) -> void {
+  if (level <= level_) {
+      log_array(convert_level(level), *logger_, s, m, n, array, ld);
+  }
+}
+
+}  // namespace bipp

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <any>
+#include <complex>
+#include <cstddef>
+#include <string>
+#include <memory>
+
+#include "bipp/bipp.h"
+#include "bipp/config.h"
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+#include "gpu/util/runtime_api.hpp"
+#endif
+
+#include <spdlog/logger.h>
+
+namespace bipp {
+
+class Logger {
+public:
+   explicit Logger(BippLogLevel level, const char* out = "stdout");
+
+   Logger(const Logger&) = delete;
+
+   Logger(Logger&&) = default;
+
+   auto operator=(const Logger&) -> Logger& = delete;
+
+   auto operator=(Logger&&) -> Logger& = default;
+
+   template <typename... Args>
+   void log(BippLogLevel level, const std::string_view& s, Args&&... args) {
+     if (level <= level_) logger_->log(convert_level(level), s, std::forward<Args>(args)...);
+   }
+
+   // log 2D arrays
+   auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const float* array, std::size_t ld) -> void;
+   auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const double* array, std::size_t ld) -> void;
+   auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const std::complex<float>* array, std::size_t ld) -> void;
+   auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const std::complex<double>* array, std::size_t ld) -> void;
+
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+   inline auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const gpu::api::ComplexType<float>* array, std::size_t ld) -> void {
+     log_matrix(level, s, m, n, reinterpret_cast<const std::complex<float>*>(array), ld);
+   }
+   inline auto log_matrix(BippLogLevel level, const std::string_view& s, std::size_t m, std::size_t n,
+                   const gpu::api::ComplexType<double>* array, std::size_t ld) -> void {
+     log_matrix(level, s, m, n, reinterpret_cast<const std::complex<double>*>(array), ld);
+   }
+#endif
+
+
+ private:
+   static auto convert_level(BippLogLevel l) -> spdlog::level::level_enum;
+
+   BippLogLevel level_;
+   std::shared_ptr<spdlog::logger> logger_;
+};
+}  // namespace bipp

--- a/src/memory/allocator.hpp
+++ b/src/memory/allocator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #include "bipp/config.h"
 #include "bipp/exceptions.hpp"

--- a/src/nufft_synthesis.cpp
+++ b/src/nufft_synthesis.cpp
@@ -2,6 +2,7 @@
 
 #include <complex>
 #include <optional>
+#include <chrono>
 
 #include "bipp/config.h"
 #include "bipp/exceptions.hpp"
@@ -24,6 +25,16 @@ struct NufftSynthesisInternal {
                          std::size_t nFilter, const BippFilter* filter, std::size_t nPixel,
                          const T* lmnX, const T* lmnY, const T* lmnZ)
       : ctx_(ctx), nAntenna_(nAntenna), nBeam_(nBeam), nIntervals_(nIntervals), nPixel_(nPixel) {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG,
+                       "{} NufftSynthesis.create({}, opt, {}, {} ,{} ,{} {}, {}, {}, {}, {})",
+                       (const void*)this, (const void*)ctx_.get(), nAntenna, nBeam, nIntervals,
+                       nFilter, (const void*)filter, nPixel, (const void*)lmnX, (const void*)lmnY,
+                       (const void*)lmnZ);
+
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnX", nPixel_, 1, lmnX, nPixel_);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnY", nPixel_, 1, lmnY, nPixel_);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnZ", nPixel_, 1, lmnZ, nPixel_);
+
     if (ctx_->processing_unit() == BIPP_PU_CPU) {
       planHost_.emplace(ctx_, std::move(opt), nAntenna, nBeam, nIntervals, nFilter, filter, nPixel, lmnX, lmnY,
                         lmnZ);
@@ -65,11 +76,35 @@ struct NufftSynthesisInternal {
       throw GPUSupportError();
 #endif
     }
+    ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} NufftSynthesis created with Context {}",
+                       static_cast<const void*>(this), (const void*)ctx_.get());
+  }
+
+  ~NufftSynthesisInternal() {
+    try{
+      ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} NufftSynthesis destroyed",
+                         static_cast<const void*>(this));
+    } catch (...) {
+    }
   }
 
   void collect(std::size_t nEig, T wl, const T* intervals, std::size_t ldIntervals,
                const std::complex<T>* s, std::size_t lds, const std::complex<T>* w, std::size_t ldw,
                const T* xyz, std::size_t ldxyz, const T* uvw, std::size_t lduvw) {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG, "------------");
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG,
+                       "{} NufftSynthesis.collect({}, {}, {}, {}, {} ,{} ,{} {}, {}, {}, {}, {})",
+                       (const void*)this, nEig, wl, (const void*)intervals, ldIntervals,
+                       (const void*)s, lds, (const void*)w, ldw, (const void*)xyz, ldxyz,
+                       (const void*)uvw, lduvw);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "intervals", 2, nIntervals_, intervals, ldIntervals);
+    if (s) ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "S", nBeam_, nBeam_, s, lds);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "W", nAntenna_, nBeam_, w, ldw);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "XYZ", nAntenna_, 3, xyz, ldxyz);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "UVW", nAntenna_ * nAntenna_, 3, uvw, lduvw);
+
+    const auto start = std::chrono::high_resolution_clock::now();
+
     if (planHost_) {
       planHost_.value().collect(nEig, wl, intervals, ldIntervals, s, lds, w, ldw, xyz, ldxyz, uvw,
                                 lduvw);
@@ -136,9 +171,29 @@ struct NufftSynthesisInternal {
       throw GPUSupportError();
 #endif
     }
+
+    const auto time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::high_resolution_clock::now() - start);
+    ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} NufftSynthesis.collect() time: {}ms",
+                       (const void*)this, time.count());
+
+    if(ctx_->processing_unit() == BIPP_PU_CPU)
+      ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} Context memory usage: host {}MB",
+                         (const void*)ctx_.get(), ctx_->host_alloc()->size() / 1000000);
+    else {
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+      const auto queueMem = ctx_->gpu_queue().allocated_memory();
+      ctx_->logger().log(
+          BIPP_LOG_LEVEL_INFO, "{} Context memory usage: host {}MB, pinned {}MB, device {}MB",
+          (const void*)ctx_.get(), (ctx_->host_alloc()->size() + std::get<0>(queueMem)) / 1000000,
+          std::get<1>(queueMem) / 1000000, std::get<2>(queueMem) / 1000000);
+#endif
+    }
   }
 
   auto get(BippFilter f, T* out, std::size_t ld) -> void {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG, "{} NufftSynthesis.get({}, {}, {})", (const void*)this,
+                       (int)f, (const void*)out, ld);
     if (planHost_) {
       planHost_.value().get(f, out, ld);
     } else {
@@ -163,24 +218,55 @@ template <typename T>
 NufftSynthesis<T>::NufftSynthesis(Context& ctx, NufftSynthesisOptions opt, std::size_t nAntenna,
                                   std::size_t nBeam, std::size_t nIntervals, std::size_t nFilter,
                                   const BippFilter* filter, std::size_t nPixel, const T* lmnX,
-                                  const T* lmnY, const T* lmnZ)
-    : plan_(new NufftSynthesisInternal<T>(InternalContextAccessor::get(ctx), std::move(opt),
-                                          nAntenna, nBeam, nIntervals, nFilter, filter, nPixel,
-                                          lmnX, lmnY, lmnZ),
-            [](auto&& ptr) { delete reinterpret_cast<NufftSynthesisInternal<T>*>(ptr); }) {}
+                                  const T* lmnY, const T* lmnZ) {
+  try {
+    plan_ = decltype(plan_)(
+        new NufftSynthesisInternal<T>(InternalContextAccessor::get(ctx), std::move(opt), nAntenna,
+                                      nBeam, nIntervals, nFilter, filter, nPixel, lmnX, lmnY, lmnZ),
+        [](auto&& ptr) { delete reinterpret_cast<NufftSynthesisInternal<T>*>(ptr); });
+  } catch (const std::exception& e) {
+    try {
+      InternalContextAccessor::get(ctx)->logger().log(
+          BIPP_LOG_LEVEL_ERROR, "NufftSynthesis creation error: {}", e.what());
+    } catch (...) {
+    }
+    throw;
+  }
+}
 
 template <typename T>
 auto NufftSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals, std::size_t ldIntervals,
                                 const std::complex<T>* s, std::size_t lds, const std::complex<T>* w,
                                 std::size_t ldw, const T* xyz, std::size_t ldxyz, const T* uvw,
                                 std::size_t lduvw) -> void {
-  reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())
-      ->collect(nEig, wl, intervals, ldIntervals, s, lds, w, ldw, xyz, ldxyz, uvw, lduvw);
+  try {
+    reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())
+        ->collect(nEig, wl, intervals, ldIntervals, s, lds, w, ldw, xyz, ldxyz, uvw, lduvw);
+  } catch (const std::exception& e) {
+    try {
+      reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())
+          ->ctx_->logger()
+          .log(BIPP_LOG_LEVEL_ERROR, "NufftSynthesis.collect() error: {}", e.what());
+    } catch (...) {
+    }
+    throw;
+  }
 }
 
 template <typename T>
 auto NufftSynthesis<T>::get(BippFilter f, T* out, std::size_t ld) -> void {
-  reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())->get(f, out, ld);
+  try {
+    reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())->get(f, out, ld);
+  } catch (const std::exception& e) {
+    try {
+      reinterpret_cast<NufftSynthesisInternal<T>*>(plan_.get())
+          ->ctx_->logger()
+          .log(BIPP_LOG_LEVEL_ERROR, "{} NufftSynthesis.get() error: {}", (const void*)plan_.get(),
+               e.what());
+    } catch (...) {
+    }
+    throw;
+  }
 }
 
 template class BIPP_EXPORT NufftSynthesis<double>;

--- a/src/standard_synthesis.cpp
+++ b/src/standard_synthesis.cpp
@@ -1,5 +1,6 @@
 #include "bipp/standard_synthesis.hpp"
 
+#include <chrono>
 #include <complex>
 #include <optional>
 
@@ -23,6 +24,16 @@ struct StandardSynthesisInternal {
                             const BippFilter* filter, std::size_t nPixel, const T* pixelX,
                             const T* pixelY, const T* pixelZ)
       : ctx_(ctx), nAntenna_(nAntenna), nBeam_(nBeam), nIntervals_(nIntervals), nPixel_(nPixel) {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG,
+                       "{} StandardSynthesis.create({}, opt, {}, {} ,{} ,{} {}, {}, {}, {}, {})",
+                       (const void*)this, (const void*)ctx_.get(), nAntenna, nBeam, nIntervals,
+                       nFilter, (const void*)filter, nPixel, (const void*)pixelX,
+                       (const void*)pixelY, (const void*)pixelZ);
+
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnX", nPixel_, 1, pixelX, nPixel_);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnY", nPixel_, 1, pixelY, nPixel_);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "lmnZ", nPixel_, 1, pixelZ, nPixel_);
+
     if (ctx_->processing_unit() == BIPP_PU_CPU) {
       planHost_.emplace(ctx_, nAntenna, nBeam, nIntervals, nFilter, filter, nPixel, pixelX, pixelY,
                         pixelZ);
@@ -65,11 +76,33 @@ struct StandardSynthesisInternal {
       throw GPUSupportError();
 #endif
     }
+    ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} StandardSynthesis created with Context {}",
+                       static_cast<const void*>(this), (const void*)ctx_.get());
+  }
+
+  ~StandardSynthesisInternal() {
+    try{
+      ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} StandardSynthesis destroyed",
+                         static_cast<const void*>(this));
+    } catch (...) {
+    }
   }
 
   void collect(std::size_t nEig, T wl, const T* intervals, std::size_t ldIntervals,
                const std::complex<T>* s, std::size_t lds, const std::complex<T>* w, std::size_t ldw,
                const T* xyz, std::size_t ldxyz) {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG, "------------");
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG,
+                       "{} NufftSynthesis.collect({}, {}, {}, {}, {} ,{} ,{} {}, {}, {})",
+                       (const void*)this, nEig, wl, (const void*)intervals, ldIntervals,
+                       (const void*)s, lds, (const void*)w, ldw, (const void*)xyz, ldxyz);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "intervals", 2, nIntervals_, intervals, ldIntervals);
+    if (s) ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "S", nBeam_, nBeam_, s, lds);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "W", nAntenna_, nBeam_, w, ldw);
+    ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "XYZ", nAntenna_, 3, xyz, ldxyz);
+
+    const auto start = std::chrono::high_resolution_clock::now();
+
     if (planHost_) {
       planHost_.value().collect(nEig, wl, intervals, ldIntervals, s, lds, w, ldw, xyz, ldxyz);
     } else {
@@ -123,9 +156,29 @@ struct StandardSynthesisInternal {
       throw GPUSupportError();
 #endif
     }
+
+    const auto time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::high_resolution_clock::now() - start);
+    ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} StandardSynthesis.collect() time: {}ms",
+                       (const void*)this, time.count());
+
+    if (ctx_->processing_unit() == BIPP_PU_CPU)
+      ctx_->logger().log(BIPP_LOG_LEVEL_INFO, "{} Context memory usage: host {}MB",
+                         (const void*)ctx_.get(), ctx_->host_alloc()->size() / 1000000);
+    else {
+#if defined(BIPP_CUDA) || defined(BIPP_ROCM)
+      const auto queueMem = ctx_->gpu_queue().allocated_memory();
+      ctx_->logger().log(
+          BIPP_LOG_LEVEL_INFO, "{} Context memory usage: host {}MB, pinned {}MB, device {}MB",
+          (const void*)ctx_.get(), (ctx_->host_alloc()->size() + std::get<0>(queueMem)) / 1000000,
+          std::get<1>(queueMem) / 1000000, std::get<2>(queueMem) / 1000000);
+#endif
+    }
   }
 
   auto get(BippFilter f, T* img, std::size_t ld) -> void {
+    ctx_->logger().log(BIPP_LOG_LEVEL_DEBUG, "{} StandardSynthesis.get({}, {}, {})",
+                       (const void*)this, (int)f, (const void*)img, ld);
     if (planHost_) {
       planHost_.value().get(f, img, ld);
     } else {
@@ -150,19 +203,41 @@ template <typename T>
 StandardSynthesis<T>::StandardSynthesis(Context& ctx, std::size_t nAntenna, std::size_t nBeam,
                                         std::size_t nIntervals, std::size_t nFilter,
                                         const BippFilter* filter, std::size_t nPixel,
-                                        const T* pixelX, const T* pixelY, const T* pixelZ)
-    : plan_(new StandardSynthesisInternal<T>(InternalContextAccessor::get(ctx), nAntenna, nBeam,
-                                             nIntervals, nFilter, filter, nPixel, pixelX, pixelY,
-                                             pixelZ),
-            [](auto&& ptr) { delete reinterpret_cast<StandardSynthesisInternal<T>*>(ptr); }) {}
+                                        const T* pixelX, const T* pixelY, const T* pixelZ) {
+  try {
+    plan_ = decltype(plan_)(
+        new StandardSynthesisInternal<T>(InternalContextAccessor::get(ctx), nAntenna, nBeam,
+                                         nIntervals, nFilter, filter, nPixel, pixelX, pixelY,
+                                         pixelZ),
+        [](auto&& ptr) { delete reinterpret_cast<StandardSynthesisInternal<T>*>(ptr); });
+  } catch (const std::exception& e) {
+    try {
+      InternalContextAccessor::get(ctx)->logger().log(
+          BIPP_LOG_LEVEL_ERROR, "StandardSynthesis creation error: {}", e.what());
+    } catch (...) {
+    }
+    throw;
+  }
+}
 
 template <typename T>
 auto StandardSynthesis<T>::collect(std::size_t nEig, T wl, const T* intervals,
                                    std::size_t ldIntervals, const std::complex<T>* s,
                                    std::size_t lds, const std::complex<T>* w, std::size_t ldw,
                                    const T* xyz, std::size_t ldxyz) -> void {
+  try {
   reinterpret_cast<StandardSynthesisInternal<T>*>(plan_.get())
       ->collect(nEig, wl, intervals, ldIntervals, s, lds, w, ldw, xyz, ldxyz);
+  } catch (const std::exception& e) {
+    try {
+      reinterpret_cast<StandardSynthesisInternal<T>*>(plan_.get())
+          ->ctx_->logger()
+          .log(BIPP_LOG_LEVEL_ERROR, "{} StandardSynthesis.get() error: {}",
+               (const void*)plan_.get(), e.what());
+    } catch (...) {
+    }
+    throw;
+  }
 }
 
 template <typename T>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ mark_as_advanced(BUILD_GMOCK INSTALL_GTEST)
 set(JSON_Install OFF CACHE BOOL "")
 set(JSON_BuildTests OFF CACHE INTERNAL "")
 
-if(BIPP_BUNDLED_LIBS)
+if(BIPP_BUNDLED_GOOGLETEST)
   # add googletest
   FetchContent_Declare(
     googletest
@@ -17,7 +17,11 @@ if(BIPP_BUNDLED_LIBS)
     URL_MD5 95b29f0038ec84a611df951d74d99897
   )
   FetchContent_MakeAvailable(googletest)
+else()
+  find_package(googletest CONFIG REQUIRED)
+endif()
 
+if(BIPP_BUNDLED_JSON)
   # add json parser
   FetchContent_Declare(
     json
@@ -25,9 +29,7 @@ if(BIPP_BUNDLED_LIBS)
     URL_MD5 e8d56bc54621037842ee9f0aeae27746
   )
   FetchContent_MakeAvailable(json)
-
 else()
-  find_package(googletest CONFIG REQUIRED)
   find_package(nlohmann_json CONFIG REQUIRED)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,38 +5,33 @@ set(BUILD_GMOCK OFF CACHE BOOL "")
 set(INSTALL_GTEST OFF CACHE BOOL "")
 mark_as_advanced(BUILD_GMOCK INSTALL_GTEST)
 
-include(FetchContent)
 
-# add googletest
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.11.0
-)
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  message(STATUS "Downloading Google Test repository...")
-  FetchContent_Populate(googletest)
-endif()
-add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
-list(APPEND BIPP_TEST_LIBRARIES gtest_main)
-
-# add json parser
 set(JSON_Install OFF CACHE BOOL "")
-FetchContent_Declare(
-  json
-  GIT_REPOSITORY https://github.com/nlohmann/json.git
-  GIT_TAG        v3.10.5
-)
-FetchContent_GetProperties(json)
-if(NOT json_POPULATED)
-  message(STATUS "Downloading json repository...")
-  FetchContent_Populate(json)
-endif()
 set(JSON_BuildTests OFF CACHE INTERNAL "")
-add_subdirectory(${json_SOURCE_DIR} ${json_BINARY_DIR})
-list(APPEND BIPP_TEST_LIBRARIES nlohmann_json::nlohmann_json)
 
+if(BIPP_BUNDLED_LIBS)
+  # add googletest
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.tar.gz
+    URL_MD5 95b29f0038ec84a611df951d74d99897
+  )
+  FetchContent_MakeAvailable(googletest)
+
+  # add json parser
+  FetchContent_Declare(
+    json
+    URL https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.tar.gz
+    URL_MD5 e8d56bc54621037842ee9f0aeae27746
+  )
+  FetchContent_MakeAvailable(json)
+
+else()
+  find_package(googletest CONFIG REQUIRED)
+  find_package(nlohmann_json CONFIG REQUIRED)
+endif()
+
+list(APPEND BIPP_TEST_LIBRARIES gtest_main nlohmann_json::nlohmann_json)
 
 # test executables
 add_executable(run_tests


### PR DESCRIPTION
This PR adds logging functionality through [spdlog](https://github.com/gabime/spdlog).
This is a header-only library and will be a mandatory dependency, that is downloaded through CMake by default. Optionally, `-DBIPP_BUNDLED_LIBS=OFF` can be specified, if an externally provided version of spdlog is available.
Logging can be controlled by setting the environment vriable `BIPP_LOG_LEVEL` to one of the following: `OFF`, `DEBUG`, `INFO`, `WARN` or `ERROR`.  When set to `DEBUG`, checksums and floating point properties are printed for input data and intermediate results, to allow for easier identification of issues.
The output is printed to `stdout` by default, but can be set to `stderr` or a file path by specifying the environment variable `BIPP_LOG_OUT`.



