### PR TITLE
Direct evaluation of NUFT sum for small sizes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(BIPP_SOURCE_FILES
 	host/nufft_3d3.cpp
 	host/virtual_vis.cpp
 	host/kernels/gemmexp.cpp
+	host/kernels/nuft_sum.cpp
 	host/standard_synthesis.cpp
 	)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ if(BIPP_CUDA OR BIPP_ROCM)
 		gpu/kernels/gemmexp.cu
 		gpu/kernels/center_vector.cu
 		gpu/kernels/min_max_element.cu
+		gpu/kernels/nuft_sum.cu
 		)
 endif()
 

--- a/src/gpu/kernels/add_vector.cu
+++ b/src/gpu/kernels/add_vector.cu
@@ -10,7 +10,7 @@ namespace bipp {
 namespace gpu {
 
 template <typename T>
-__global__ static void add_vector_real_to_complex_kernel(std::size_t n,
+__global__ static void add_vector_real_of_complex_kernel(std::size_t n,
                                                          const api::ComplexType<T>* __restrict__ a,
                                                          T* __restrict__ b) {
   for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
@@ -19,19 +19,21 @@ __global__ static void add_vector_real_to_complex_kernel(std::size_t n,
 }
 
 template <typename T>
-auto add_vector_real_to_complex(Queue& q, std::size_t n, const api::ComplexType<T>* a, T* b)
-    -> void {
+auto add_vector_real_of_complex(const api::DevicePropType& prop, const api::StreamType& stream,
+                                std::size_t n, const api::ComplexType<T>* a, T* b) -> void {
   constexpr int blockSize = 256;
 
-  const dim3 block(std::min<int>(blockSize, q.device_prop().maxThreadsDim[0]), 1, 1);
-  const auto grid = kernel_launch_grid(q.device_prop(), {n, 1, 1}, block);
-  api::launch_kernel(add_vector_real_to_complex_kernel<T>, grid, block, 0, q.stream(), n, a, b);
+  const dim3 block(std::min<int>(blockSize, prop.maxThreadsDim[0]), 1, 1);
+  const auto grid = kernel_launch_grid(prop, {n, 1, 1}, block);
+  api::launch_kernel(add_vector_real_of_complex_kernel<T>, grid, block, 0, stream, n, a, b);
 }
 
-template auto add_vector_real_to_complex<float>(Queue& q, std::size_t n,
+template auto add_vector_real_of_complex<float>(const api::DevicePropType& prop,
+                                                const api::StreamType& stream, std::size_t n,
                                                 const api::ComplexType<float>* a, float* b) -> void;
 
-template auto add_vector_real_to_complex<double>(Queue& q, std::size_t n,
+template auto add_vector_real_of_complex<double>(const api::DevicePropType& prop,
+                                                 const api::StreamType& stream, std::size_t n,
                                                  const api::ComplexType<double>* a, double* b)
     -> void;
 

--- a/src/gpu/kernels/add_vector.hpp
+++ b/src/gpu/kernels/add_vector.hpp
@@ -8,7 +8,7 @@
 namespace bipp {
 namespace gpu {
 template <typename T>
-auto add_vector_real_to_complex(Queue& q, std::size_t n, const api::ComplexType<T>* a, T* b)
-    -> void;
+auto add_vector_real_of_complex(const api::DevicePropType& prop, const api::StreamType& stream,
+                                std::size_t n, const api::ComplexType<T>* a, T* b) -> void;
 }
 }  // namespace bipp

--- a/src/gpu/kernels/nuft_sum.cu
+++ b/src/gpu/kernels/nuft_sum.cu
@@ -1,0 +1,98 @@
+#include <algorithm>
+#include <cstddef>
+
+#include "bipp/config.h"
+#include "gpu/kernels/nuft_sum.hpp"
+#include "gpu/util/cub_api.hpp"
+#include "gpu/util/kernel_launch_grid.hpp"
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+namespace {
+
+__device__ __forceinline__ void calc_sincos(float x, float* sptr, float* cptr) {
+  sincosf(x, sptr, cptr);
+}
+
+__device__ __forceinline__ void calc_sincos(double x, double* sptr, double* cptr) {
+  sincos(x, sptr, cptr);
+}
+
+template <typename T, int BLOCK_THREADS, api::cub::BlockReduceAlgorithm ALGORITHM>
+__global__ __launch_bounds__(BLOCK_THREADS) void nuft_sum_kernel(
+    T alpha, std::size_t nIn, const api::ComplexType<T>* __restrict__ input,
+    const T* __restrict__ u, const T* __restrict__ v, const T* __restrict__ w, std::size_t nOut,
+    const T* __restrict__ x, const T* __restrict__ y, const T* __restrict__ z, T* out) {
+  using BlockReduceType = api::cub::BlockReduce<T, BLOCK_THREADS, ALGORITHM>;
+  __shared__ typename BlockReduceType::TempStorage tmpStorage;
+
+  for (std::size_t idxOut = blockIdx.x; idxOut < nOut; idxOut += gridDim.x) {
+    const auto xVal = x[idxOut];
+    const auto yVal = y[idxOut];
+    const auto zVal = z[idxOut];
+
+    T localSum = 0;
+    for (std::size_t idxIn = threadIdx.x; idxIn < nIn; idxIn += BLOCK_THREADS) {
+      const auto imag = alpha * (xVal * u[idxIn] + yVal * v[idxIn] + zVal * w[idxIn]);
+      api::ComplexType<T> sc;
+      calc_sincos(imag, &(sc.y), &(sc.x));
+      const auto inVal = input[idxIn];
+      localSum += inVal.x * sc.x - inVal.y * sc.y;
+    }
+
+    auto totalSum = BlockReduceType(tmpStorage).Sum(localSum);
+    if (threadIdx.x == 0) {
+      out[idxOut] += totalSum;
+    }
+  }
+}
+
+template <typename T, int BLOCK_THREADS>
+auto nuft_sum_launch(const api::DevicePropType& prop, const api::StreamType& stream, T alpha,
+                     std::size_t nIn, const api::ComplexType<T>* __restrict__ input, const T* u,
+                     const T* v, const T* w, std::size_t nOut, const T* x, const T* y, const T* z,
+                     T* out) -> void {
+  const dim3 block(BLOCK_THREADS, 1, 1);
+  const auto grid = kernel_launch_grid(prop, {nOut, 1, 1}, block);
+
+  api::launch_kernel(nuft_sum_kernel<T, BLOCK_THREADS,
+                                     api::cub::BlockReduceAlgorithm::BLOCK_REDUCE_WARP_REDUCTIONS>,
+                     grid, block, 0, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+}
+
+}  // namespace
+
+template <typename T>
+auto nuft_sum(const api::DevicePropType& prop, const api::StreamType& stream, T alpha,
+              std::size_t nIn, const api::ComplexType<T>* __restrict__ input, const T* u,
+              const T* v, const T* w, std::size_t nOut, const T* x, const T* y, const T* z, T* out)
+    -> void {
+  if (nIn >= 1024 && prop.maxThreadsDim[0] >= 1024) {
+    nuft_sum_launch<T, 1024>(prop, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+  } else if (nIn >= 512 && prop.maxThreadsDim[0] >= 512) {
+    nuft_sum_launch<T, 512>(prop, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+  } else if (nIn >= 256 && prop.maxThreadsDim[0] >= 256) {
+    nuft_sum_launch<T, 256>(prop, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+  } else if (nIn >= 128 && prop.maxThreadsDim[0] >= 128) {
+    nuft_sum_launch<T, 128>(prop, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+  } else {
+    nuft_sum_launch<T, 64>(prop, stream, alpha, nIn, input, u, v, w, nOut, x, y, z, out);
+  }
+}
+
+template auto nuft_sum<float>(const api::DevicePropType& prop, const api::StreamType& stream,
+                              float alpha, std::size_t nIn,
+                              const api::ComplexType<float>* __restrict__ input, const float* u,
+                              const float* v, const float* w, std::size_t nOut, const float* x,
+                              const float* y, const float* z, float* out) -> void;
+
+template auto nuft_sum<double>(const api::DevicePropType& prop, const api::StreamType& stream,
+                               double alpha, std::size_t nIn,
+                               const api::ComplexType<double>* __restrict__ input, const double* u,
+                               const double* v, const double* w, std::size_t nOut, const double* x,
+                               const double* y, const double* z, double* out) -> void;
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/kernels/nuft_sum.hpp
+++ b/src/gpu/kernels/nuft_sum.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstddef>
+
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+// Direct computation of the type 3 NUFT sum, where only the real valued output is considered
+template <typename T>
+auto nuft_sum(const api::DevicePropType& prop, const api::StreamType& stream, T alpha,
+              std::size_t nIn, const api::ComplexType<T>* __restrict__ input, const T* u,
+              const T* v, const T* w, std::size_t nOut, const T* x, const T* y, const T* z, T* out)
+    -> void;
+}  // namespace gpu
+}  // namespace bipp

--- a/src/host/kernels/gemmexp.cpp
+++ b/src/host/kernels/gemmexp.cpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <complex>
-#include <iostream>
 
 #include "host/omp_definitions.hpp"
 

--- a/src/host/kernels/nuft_sum.cpp
+++ b/src/host/kernels/nuft_sum.cpp
@@ -1,0 +1,47 @@
+#include "host/kernels/nuft_sum.hpp"
+
+#include <cmath>
+#include <complex>
+
+#include "host/omp_definitions.hpp"
+
+namespace bipp {
+namespace host {
+
+template <typename T>
+auto nuft_sum(T alpha, std::size_t nIn, const std::complex<T>* __restrict__ input, const T* u,
+              const T* v, const T* w, std::size_t nOut, const T* x, const T* y, const T* z, T* out)
+    -> void {
+  BIPP_OMP_PRAGMA("omp parallel for schedule(static)")
+  for (std::size_t idxOut = 0; idxOut < nOut; ++idxOut) {
+    const auto xVal = x[idxOut];
+    const auto yVal = y[idxOut];
+    const auto zVal = z[idxOut];
+
+    T sum = 0;
+    for (std::size_t idxIn = 0; idxIn < nIn; ++idxIn) {
+      const auto p = alpha * (xVal * u[idxIn] + yVal * v[idxIn] + zVal * w[idxIn]);
+      const auto real = std::cos(p);
+      const auto imag = std::sin(p);
+
+      const auto inVal = input[idxIn];
+
+      sum += inVal.real() * real - inVal.imag() * imag;
+    }
+
+    out[idxOut] += sum;
+  }
+}
+
+template auto nuft_sum<float>(float alpha, std::size_t nIn,
+                              const std::complex<float>* __restrict__ input, const float* u,
+                              const float* v, const float* w, std::size_t nOut, const float* x,
+                              const float* y, const float* z, float* out) -> void;
+
+template auto nuft_sum<double>(double alpha, std::size_t nIn,
+                               const std::complex<double>* __restrict__ input, const double* u,
+                               const double* v, const double* w, std::size_t nOut, const double* x,
+                               const double* y, const double* z, double* out) -> void;
+
+}  // namespace host
+}  // namespace bipp

--- a/src/host/kernels/nuft_sum.hpp
+++ b/src/host/kernels/nuft_sum.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <complex>
+
+#include "bipp/config.h"
+
+namespace bipp {
+namespace host {
+
+template <typename T>
+auto nuft_sum(T alpha, std::size_t nIn, const std::complex<T>* __restrict__ input, const T* u,
+              const T* v, const T* w, std::size_t nOut, const T* x, const T* y, const T* z, T* out)
+    -> void;
+
+}  // namespace host
+}  // namespace bipp

--- a/src/host/standard_synthesis.cpp
+++ b/src/host/standard_synthesis.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <complex>
-#include <iostream>
 #include <limits>
 
 #include "bipp/bipp.h"


### PR DESCRIPTION
This PR adds direct evaluation of the NUFT sum for small input sizes.
Tested with the SKA-Low dataset with around a 25% performance improvement on GPU (depending on the domain partitioning).
