### PR TITLE
Fix parameter estimator by discarding negative eigenvalues

### DIFF
--- a/python/bipp/parameter_estimator.py
+++ b/python/bipp/parameter_estimator.py
@@ -169,6 +169,8 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
             # Functional PCA
             if not np.allclose(S, 0):
                 _, D, _ = bipp.pybipp.eigh(self._ctx, S.data.shape[0], S.data, G.data)
+                # only consider positive eigenvalues, since we apply the log function for clustering
+                D = D[D > 0.0]
                 idx = np.clip(np.cumsum(D) / np.sum(D), 0, 1) <= self._sigma
                 D = D[idx]
                 D_all[i, : len(D)] = D


### PR DESCRIPTION
The new eigensolver function also returns negative eigenvalues.
In the parameter estimator, we apply the log function, so we need to discard these for clustering.