### PR TITLE
Scale output image by number of steps

### DIFF
--- a/python/bipp/parameter_estimator.py
+++ b/python/bipp/parameter_estimator.py
@@ -169,6 +169,8 @@ class IntensityFieldParameterEstimator(ParameterEstimator):
             # Functional PCA
             if not np.allclose(S, 0):
                 _, D, _ = bipp.pybipp.eigh(self._ctx, S.data.shape[0], S.data, G.data)
+                # only consider positive eigenvalues, since we apply the log function for clustering
+                D = D[D > 0.0]
                 idx = np.clip(np.cumsum(D) / np.sum(D), 0, 1) <= self._sigma
                 D = D[idx]
                 D_all[i, : len(D)] = D

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ if(BIPP_CUDA OR BIPP_ROCM)
 		gpu/kernels/min_max_element.cu
 		gpu/kernels/nuft_sum.cu
 		gpu/kernels/copy_at_indices.cu
+		gpu/kernels/scale_vector.cu
 		)
 endif()
 

--- a/src/gpu/kernels/scale_vector.cu
+++ b/src/gpu/kernels/scale_vector.cu
@@ -1,0 +1,60 @@
+#include <algorithm>
+
+#include "bipp//config.h"
+#include "gpu/kernels/scale_vector.hpp"
+#include "gpu/util/kernel_launch_grid.hpp"
+#include "gpu/util/runtime.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+
+template <typename T>
+__global__ static void scale_vector_kernel(std::size_t n, const T* __restrict__ a, T alpha,
+                                           T* __restrict__ b) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    b[i] = alpha * a[i];
+  }
+}
+
+template <typename T>
+__global__ static void scale_vector_inplace_kernel(std::size_t n, T alpha, T* a) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    a[i] *= alpha;
+  }
+}
+
+template <typename T>
+auto scale_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                  const T* a, T alpha, T* b) -> void {
+  constexpr int blockSize = 256;
+
+  const dim3 block(std::min<int>(blockSize, prop.maxThreadsDim[0]), 1, 1);
+  const auto grid = kernel_launch_grid(prop, {n, 1, 1}, block);
+  api::launch_kernel(scale_vector_kernel<T>, grid, block, 0, stream, n, a, alpha, b);
+}
+
+template <typename T>
+auto scale_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                  T alpha, T* a) -> void {
+  constexpr int blockSize = 256;
+
+  const dim3 block(std::min<int>(blockSize, prop.maxThreadsDim[0]), 1, 1);
+  const auto grid = kernel_launch_grid(prop, {n, 1, 1}, block);
+  api::launch_kernel(scale_vector_inplace_kernel<T>, grid, block, 0, stream, n, alpha, a);
+}
+
+template auto scale_vector<float>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                  std::size_t n, const float* a, float alpha, float* b) -> void;
+
+template auto scale_vector<double>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                   std::size_t n, const double* a, double alpha, double* b) -> void;
+
+template auto scale_vector<float>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                  std::size_t n, float alpha, float* a) -> void;
+
+template auto scale_vector<double>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                   std::size_t n, double alpha, double* a) -> void;
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/kernels/scale_vector.hpp
+++ b/src/gpu/kernels/scale_vector.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstddef>
+
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+
+// Compute b = alpha * a;
+template <typename T>
+auto scale_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                  const T* a, T alpha, T* b) -> void;
+
+// Compute a = alpha * a;
+template <typename T>
+auto scale_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                  T alpha, T* a) -> void;
+}
+}  // namespace bipp

--- a/src/gpu/nufft_synthesis.hpp
+++ b/src/gpu/nufft_synthesis.hpp
@@ -37,7 +37,7 @@ private:
   Buffer<T> lmnX_, lmnY_, lmnZ_;
   DomainPartition imgPartition_;
 
-  std::size_t nMaxInputCount_, collectCount_;
+  std::size_t nMaxInputCount_, collectCount_, totalCollectCount_;
   Buffer<api::ComplexType<T>> virtualVis_;
   Buffer<T> uvwX_, uvwY_, uvwZ_;
   Buffer<T> img_;

--- a/src/gpu/standard_synthesis.hpp
+++ b/src/gpu/standard_synthesis.hpp
@@ -26,6 +26,7 @@ public:
 private:
   std::shared_ptr<ContextInternal> ctx_;
   const std::size_t nIntervals_, nFilter_, nPixel_, nAntenna_, nBeam_;
+  std::size_t count_;
   Buffer<BippFilter> filterHost_;
   Buffer<T> pixelX_, pixelY_, pixelZ_;
   Buffer<T> img_;

--- a/src/host/nufft_synthesis.hpp
+++ b/src/host/nufft_synthesis.hpp
@@ -40,7 +40,7 @@ private:
   Buffer<T> lmnX_, lmnY_, lmnZ_;
   DomainPartition imgPartition_;
 
-  std::size_t nMaxInputCount_, collectCount_;
+  std::size_t nMaxInputCount_, collectCount_, totalCollectCount_;
   Buffer<std::complex<T>> virtualVis_;
   Buffer<T> uvwX_, uvwY_, uvwZ_;
   Buffer<T> img_;

--- a/src/host/standard_synthesis.hpp
+++ b/src/host/standard_synthesis.hpp
@@ -31,6 +31,7 @@ private:
 
   std::shared_ptr<ContextInternal> ctx_;
   const std::size_t nIntervals_, nFilter_, nPixel_, nAntenna_, nBeam_;
+  std::size_t count_;
   Buffer<BippFilter> filter_;
   Buffer<T> pixelX_, pixelY_, pixelZ_;
   Buffer<T> img_;

--- a/tests/test_nufft_synthesis_lofar.cpp
+++ b/tests/test_nufft_synthesis_lofar.cpp
@@ -107,6 +107,7 @@ protected:
     bipp::NufftSynthesis<T> imager(ctx_, bipp::NufftSynthesisOptions(), nAntenna, nBeam, nIntervals,
                                    1, &filter, nPixel, lmnX.data(), lmnY.data(), lmnZ.data());
 
+    std::size_t nEpochs = 0;
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);
       auto uvw = read_json_scalar_2d<ValueType>(itData["uvw"]);
@@ -115,6 +116,7 @@ protected:
 
       imager.collect(nEig, wl, intervals.data(), 2, s.data(), nBeam, w.data(), nAntenna, xyz.data(),
                      nAntenna, uvw.data(), nAntenna * nAntenna);
+      ++nEpochs;
     }
 
     std::vector<T> img(imgRef.size());
@@ -123,7 +125,8 @@ protected:
     for (std::size_t i = 0; i < img.size(); ++i) {
       // Single precision is very inaccurate due to different summation orders
       // Use twice the absolute error for single precision
-      ASSERT_NEAR(img[i], imgRef[i], 50 * (4.0 / sizeof(T)));
+      // Note: image reference is not scaling by number of epochs
+      ASSERT_NEAR(img[i] * nEpochs, imgRef[i], 50 * (4.0 / sizeof(T)));
     }
   }
 
@@ -148,6 +151,7 @@ protected:
     bipp::NufftSynthesis<T> imager(ctx_, bipp::NufftSynthesisOptions(), nAntenna, nBeam, nIntervals,
                                    1, &filter, nPixel, lmnX.data(), lmnY.data(), lmnZ.data());
 
+    std::size_t nEpochs = 0;
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);
       auto uvw = read_json_scalar_2d<ValueType>(itData["uvw"]);
@@ -155,6 +159,7 @@ protected:
 
       imager.collect(nEig, wl, intervals.data(), 2, nullptr, 0, w.data(), nAntenna, xyz.data(),
                      nAntenna, uvw.data(), nAntenna * nAntenna);
+      ++nEpochs;
     }
 
     std::vector<T> img(imgRef.size());
@@ -163,7 +168,8 @@ protected:
     for (std::size_t i = 0; i < img.size(); ++i) {
       // Single precision is very inaccurate due to different summation orders
       // Use twice the absolute error for single precision
-      ASSERT_NEAR(img[i], imgRef[i], 0.05 * (4.0 / sizeof(T)));
+      // Note: image reference is not scaling by number of epochs
+      ASSERT_NEAR(img[i] * nEpochs, imgRef[i], 0.05 * (4.0 / sizeof(T)));
     }
   }
 

--- a/tests/test_standard_synthesis_lofar.cpp
+++ b/tests/test_standard_synthesis_lofar.cpp
@@ -106,6 +106,7 @@ protected:
     bipp::StandardSynthesis<T> imager(ctx_, nAntenna, nBeam, nIntervals, 1, &filter, nPixel,
                                       pixelX.data(), pixelY.data(), pixelZ.data());
 
+    std::size_t nEpochs = 0;
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);
       auto w = read_json_complex_2d<ValueType>(itData["w_real"], itData["w_imag"]);
@@ -113,6 +114,7 @@ protected:
 
       imager.collect(nEig, wl, intervals.data(), 2, s.data(), nBeam, w.data(), nAntenna, xyz.data(),
                      nAntenna);
+      ++nEpochs;
     }
 
     std::vector<T> img(imgRef.size());
@@ -121,7 +123,8 @@ protected:
     for (std::size_t i = 0; i < img.size(); ++i) {
       // Single precision is very inaccurate due to different summation orders
       // Use twice the absolute error for single precision
-      ASSERT_NEAR(img[i], imgRef[i], 15 * (4.0 / sizeof(T)));
+      // Note: image reference is not scaling by number of epochs
+      ASSERT_NEAR(img[i] * nEpochs, imgRef[i], 15 * (4.0 / sizeof(T)));
     }
   }
 
@@ -145,12 +148,14 @@ protected:
     bipp::StandardSynthesis<T> imager(ctx_, nAntenna, nBeam, nIntervals, 1, &filter, nPixel,
                                       pixelX.data(), pixelY.data(), pixelZ.data());
 
+    std::size_t nEpochs = 0;
     for (const auto& itData : data["data"]) {
       auto xyz = read_json_scalar_2d<ValueType>(itData["xyz"]);
       auto w = read_json_complex_2d<ValueType>(itData["w_real"], itData["w_imag"]);
 
       imager.collect(nEig, wl, intervals.data(), 2, nullptr, 0, w.data(), nAntenna, xyz.data(),
                      nAntenna);
+      ++nEpochs;
     }
 
     std::vector<T> img(imgRef.size());
@@ -159,7 +164,8 @@ protected:
     for (std::size_t i = 0; i < img.size(); ++i) {
       // Single precision is very inaccurate due to different summation orders
       // Use twice the absolute error for single precision
-      ASSERT_NEAR(img[i], imgRef[i], 0.05 * (4.0 / sizeof(T)));
+      // Note: image reference is not scaling by number of epochs
+      ASSERT_NEAR(img[i] * nEpochs, imgRef[i], 0.05 * (4.0 / sizeof(T)));
     }
   }
 


### PR DESCRIPTION
Implements the scaling of the output image through division by the number of time steps as proposed by @orliac .
