### PR TITLE
Fix gram matrix

### DIFF
--- a/src/host/gram_matrix.cpp
+++ b/src/host/gram_matrix.cpp
@@ -20,8 +20,9 @@ namespace bipp {
 namespace host {
 
 template <typename T>
-static T calc_pi_sinc(T a, T x) {
-  return x ? std::sin(a * x) / x : T(3.14159265358979323846);
+static T calc_pi_sinc(T x) {
+  constexpr auto pi = T(3.14159265358979323846);
+  return x ? std::sin(pi * x) / x : pi;
 }
 
 template <typename T>
@@ -34,7 +35,8 @@ auto gram_matrix(ContextInternal& ctx, std::size_t m, std::size_t n, const std::
   auto x = xyz;
   auto y = xyz + ldxyz;
   auto z = xyz + 2 * ldxyz;
-  T sincScale = 2 * 3.14159265358979323846 / wl;
+
+  const auto sincScale = T(2.0 / wl);
   for (std::size_t i = 0; i < m; ++i) {
     basePtr[i * m + i] = 4 * 3.14159265358979323846;
     for (std::size_t j = i + 1; j < m; ++j) {
@@ -42,7 +44,8 @@ auto gram_matrix(ContextInternal& ctx, std::size_t m, std::size_t n, const std::
       auto diffY = y[i] - y[j];
       auto diffZ = z[i] - z[j];
       auto norm = std::sqrt(diffX * diffX + diffY * diffY + diffZ * diffZ);
-      basePtr[i * m + j] = 4 * calc_pi_sinc(sincScale, norm);
+      // we compute 4 * pi * sinc((2/wl) * norm), where multiplication and division by pi is removed
+      basePtr[i * m + j] = 4 * calc_pi_sinc(sincScale * norm);
     }
   }
 


### PR DESCRIPTION
The original gram matrix calculation was:
```python
(4 * np.pi) * np.sinc((2 / wl) * baseline)
```
The sinc function is not correctly implemented and we do not divide by `2/wl`.