### PR TITLE
Add readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+formats: []
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+python:
+  system_packages: true
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Readthedocs now requires a config file.
This should fix the failing documentation build job.