### PR TITLE
Add psf generation for nufft synthesis

### DIFF
--- a/examples/simulation/lofar_bootes_nufft.py
+++ b/examples/simulation/lofar_bootes_nufft.py
@@ -83,6 +83,7 @@ opt.set_tolerance(1e-3)
 # Possible options are "grid", "none" or "auto"
 opt.set_local_image_partition(bipp.Partition.grid([1,1,1]))
 opt.set_local_uvw_partition(bipp.Partition.none())
+opt.set_psf(True)
 precision = "single"
 
 
@@ -175,6 +176,8 @@ ax.set_title(
 )
 
 plt.savefig("nufft_synthesis_std.png")
+
+
 plt.figure()
 titles = ["Strong sources", "Mild sources", "Faint Sources"]
 for i in range(lsq_image.shape[0]):
@@ -192,4 +195,22 @@ for i in range(lsq_image.shape[0]):
 
 plt.suptitle(f"Bipp Eigenmaps")
 plt.savefig("nufft_synthesis_lsq.png")
+
+if opt.psf:
+    psf = imager.get_psf().reshape((N_pix, N_pix))
+    I_psf = s2image.Image(psf, xyz_grid)
+    plt.figure()
+    ax = plt.gca()
+    I_lsq_eq.draw(
+        catalog=sky_model.xyz.T,
+        ax=ax,
+        data_kwargs=dict(cmap="cubehelix"),
+        show_gridlines=False,
+        catalog_kwargs=dict(s=30, linewidths=0.5, alpha=0.5),
+    )
+    ax.set_title(
+        f"Bipp PSF (NUFFT)\n"
+    )
+    plt.savefig("nufft_synthesis_psf.png")
+
 plt.show()

--- a/include/bipp/bipp.h
+++ b/include/bipp/bipp.h
@@ -263,6 +263,16 @@ BIPP_EXPORT BippError bipp_ns_options_set_normalize_image_by_nvis(BippNufftSynth
                                                                   bool normalize);
 
 /**
+ * Generate psf image.
+ *
+ * @param[in] opt Options handle.
+ * @param[in] psf True or false.
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_ns_options_set_psf(BippNufftSynthesisOptions opt, bool psf);
+
+
+/**
  * Create a nufft synthesis plan.
  *
  * @param[in] ctx Context handle.
@@ -385,6 +395,24 @@ BIPP_EXPORT BippError bipp_nufft_synthesis_get_f(BippNufftSynthesisF plan, float
  * @return Error code or BIPP_SUCCESS.
  */
 BIPP_EXPORT BippError bipp_nufft_synthesis_get(BippNufftSynthesisF plan, double* img, size_t ld);
+
+/**
+ * Get psf image.
+ *
+ * @param[in] plan Plan handle.
+ * @param[out] img 2D image array of size (nPixel, nImages).
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_nufft_synthesis_get_psf_f(BippNufftSynthesisF plan, float* img);
+
+/**
+ * Get psf image.
+ *
+ * @param[in] plan Plan handle.
+ * @param[out] img 2D image array of size (nPixel, nImages).
+ * @return Error code or BIPP_SUCCESS.
+ */
+BIPP_EXPORT BippError bipp_nufft_synthesis_get_psf(BippNufftSynthesisF plan, double* img);
 
 /**
  * Create a standard synthesis plan.

--- a/include/bipp/errors.h
+++ b/include/bipp/errors.h
@@ -28,6 +28,10 @@ enum BippError {
    */
   BIPP_INVALID_HANDLE_ERROR,
   /**
+   * Invalid handle error.
+   */
+  BIPP_INVALID_CALL_ERROR,
+  /**
    * Eigensolver error.
    */
   BIPP_EIGENSOLVER_ERROR,

--- a/include/bipp/exceptions.hpp
+++ b/include/bipp/exceptions.hpp
@@ -59,6 +59,22 @@ public:
   }
 };
 
+class BIPP_EXPORT InvalidCallError : public GenericError {
+public:
+  InvalidCallError() : msg_("BIPP: Invalid call error") {}
+
+  // Only to be used with string literals
+  template <std::size_t N>
+  InvalidCallError(const char (&msg)[N]) : msg_(msg) {}
+
+  const char* what() const noexcept override { return msg_; }
+
+  BippError error_code() const noexcept override { return BippError::BIPP_INVALID_CALL_ERROR; }
+
+private:
+  const char* msg_;
+};
+
 class BIPP_EXPORT EigensolverError : public GenericError {
 public:
   const char* what() const noexcept override { return "BIPP: Eigensolver error"; }

--- a/include/bipp/nufft_synthesis.hpp
+++ b/include/bipp/nufft_synthesis.hpp
@@ -81,6 +81,11 @@ struct NufftSynthesisOptions {
   bool normalizeImageNvis = true;
 
   /**
+   * Generate psf image.
+   */
+  bool psf = false;
+
+  /**
    * Set the tolerance.
    *
    * @param[in] tol Tolerance.
@@ -139,6 +144,16 @@ struct NufftSynthesisOptions {
     normalizeImageNvis = normalize;
     return *this;
   }
+
+  /**
+   * Set psf image generation.
+   *
+   * @param[in] psf True or false.
+   */
+  inline auto set_psf(bool p) -> NufftSynthesisOptions& {
+    psf = p;
+    return *this;
+  }
 };
 
 template <typename T>
@@ -189,11 +204,18 @@ public:
   /**
    * Get image.
    *
-   * @param[out] img 2D image array of size (nPixel, nImagers).
+   * @param[out] img 2D image array of size (nPixel, nImages).
    * @param[in] ld Leading dimension of img.
    */
   auto get(T* img, std::size_t ld) -> void;
 
+
+  /**
+   * Get the psf. Only available if the Options enabled psf.
+   *
+   * @param[out] img 1D image array of size (nPixel).
+   */
+  auto get_psf(T* img) -> void;
 private:
   /*! \cond PRIVATE */
   std::unique_ptr<void, std::function<void(void*)>> plan_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,7 @@ if(BIPP_CUDA OR BIPP_ROCM)
 		gpu/kernels/nuft_sum.cu
 		gpu/kernels/copy_at_indices.cu
 		gpu/kernels/scale_vector.cu
+		gpu/kernels/init_vector.cu
 		)
 endif()
 

--- a/src/communicator_internal.hpp
+++ b/src/communicator_internal.hpp
@@ -64,6 +64,14 @@ class CommunicatorInternal {
     auto gather_image(std::size_t id, ConstHostView<PartitionGroup, 1> groups, HostView<T, 2> img)
         -> void;
 
+
+    // Must only be called by root
+    template <typename T,
+              typename = std::enable_if_t<std::is_same_v<T, float> || std::is_same_v<T, double>>>
+    auto gather_psf(std::size_t id, ConstHostView<PartitionGroup, 1> groups,
+                    HostView<T, 1> img) -> void;
+
+
     ~CommunicatorInternal();
 
   private:

--- a/src/distributed_synthesis.hpp
+++ b/src/distributed_synthesis.hpp
@@ -32,6 +32,8 @@ public:
 
   auto get(View<T, 2> out) -> void override;
 
+  auto get_psf(View<T, 1> out) -> void override;
+
   auto type() const -> SynthesisType override { return type_; }
 
   auto context() -> const std::shared_ptr<ContextInternal>& override { return ctx_; }
@@ -47,6 +49,7 @@ private:
   std::size_t totalCollectCount_;
   std::size_t totalVisibilityCount_;
   HostArray<T, 2> img_;
+  HostArray<T, 1> psf_img_;
   host::DomainPartition imgPartition_;
   SynthesisType type_;
   bool normalize_by_nvis_;

--- a/src/gpu/kernels/init_vector.cu
+++ b/src/gpu/kernels/init_vector.cu
@@ -1,0 +1,46 @@
+#include <algorithm>
+
+#include "bipp//config.h"
+#include "gpu/kernels/init_vector.hpp"
+#include "gpu/util/kernel_launch_grid.hpp"
+#include "gpu/util/runtime.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+
+template <typename T>
+__global__ static void init_vector_kernel(std::size_t n, T value, T* __restrict__ a) {
+  for (std::size_t i = threadIdx.x + blockIdx.x * blockDim.x; i < n; i += gridDim.x * blockDim.x) {
+    a[i] = value;
+  }
+}
+
+template <typename T>
+auto init_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                 T value, T* a) -> void {
+  constexpr int blockSize = 256;
+
+  const dim3 block(std::min<int>(blockSize, prop.maxThreadsDim[0]), 1, 1);
+  const auto grid = kernel_launch_grid(prop, {n, 1, 1}, block);
+  api::launch_kernel(init_vector_kernel<T>, grid, block, 0, stream, n, value, a);
+}
+
+template auto init_vector<float>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                 std::size_t n, float value, float* a) -> void;
+
+template auto init_vector<double>(const api::DevicePropType& prop, const api::StreamType& stream,
+                                  std::size_t n, double value, double* a) -> void;
+
+template auto init_vector<api::ComplexType<float>>(const api::DevicePropType& prop,
+                                                   const api::StreamType& stream, std::size_t n,
+                                                   api::ComplexType<float> value,
+                                                   api::ComplexType<float>* a) -> void;
+
+template auto init_vector<api::ComplexType<double>>(const api::DevicePropType& prop,
+                                                    const api::StreamType& stream, std::size_t n,
+                                                    api::ComplexType<double> value,
+                                                    api::ComplexType<double>* a) -> void;
+
+}  // namespace gpu
+}  // namespace bipp

--- a/src/gpu/kernels/init_vector.hpp
+++ b/src/gpu/kernels/init_vector.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstddef>
+
+#include "gpu/util/queue.hpp"
+#include "gpu/util/runtime_api.hpp"
+
+namespace bipp {
+namespace gpu {
+template <typename T>
+auto init_vector(const api::DevicePropType& prop, const api::StreamType& stream, std::size_t n,
+                 T value, T* a) -> void;
+}
+}  // namespace bipp

--- a/src/gpu/nufft_synthesis.cpp
+++ b/src/gpu/nufft_synthesis.cpp
@@ -265,7 +265,7 @@ auto NufftSynthesis<T>::process(CollectorInterface<T>& collector) -> void {
         }
         if (psf_img_.size()) {
           auto imgPtr = psf_img_.data() + imgBegin;
-          auto virtVisCurrentSlice = psf_input.sub_view(inputBegin, inputSize);
+          auto virtVisCurrentSlice = psf_input.sub_view(0, inputSize);
           ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "NUFFT input", virtVisCurrentSlice);
           transform.execute(virtVisCurrentSlice.data(), output.data());
           ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "NUFFT output", imgSize, 1, output.data(),

--- a/src/gpu/nufft_synthesis.hpp
+++ b/src/gpu/nufft_synthesis.hpp
@@ -21,6 +21,8 @@ public:
 
   auto get(View<T, 2> out) -> void override;
 
+  auto get_psf(View<T, 1> out) -> void override;
+
   auto type() const -> SynthesisType override { return SynthesisType::NUFFT; }
 
   auto context() -> const std::shared_ptr<ContextInternal>& override { return ctx_; }
@@ -39,6 +41,7 @@ private:
   std::size_t totalCollectCount_;
   std::size_t totalVisibilityCount_;
   DeviceArray<T, 2> img_;
+  DeviceArray<T, 1> psf_img_;
 };
 
 }  // namespace gpu

--- a/src/gpu/standard_synthesis.hpp
+++ b/src/gpu/standard_synthesis.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bipp/config.h"
+#include "bipp/exceptions.hpp"
 #include "bipp/standard_synthesis.hpp"
 #include "context_internal.hpp"
 #include "gpu/util/runtime_api.hpp"
@@ -20,6 +21,8 @@ public:
   auto process(CollectorInterface<T>& collector) -> void override;
 
   auto get(View<T, 2> out) -> void override;
+
+  auto get_psf(View<T, 1> out) -> void override { throw NotImplementedError(); }
 
   auto type() const -> SynthesisType override { return SynthesisType::Standard; }
 

--- a/src/host/nufft_synthesis.cpp
+++ b/src/host/nufft_synthesis.cpp
@@ -252,7 +252,7 @@ auto NufftSynthesis<T>::process(CollectorInterface<T>& collector) -> void {
           }
 
           if (psf_img_.size()) {
-            auto virtVisCurrentSlice = psf_input.sub_view(inputBegin, inputSize);
+            auto virtVisCurrentSlice = psf_input.sub_view(0, inputSize);
             ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "NUFFT input", virtVisCurrentSlice);
             transform.execute(virtVisCurrentSlice.data(), output.data());
             ctx_->logger().log_matrix(BIPP_LOG_LEVEL_DEBUG, "NUFFT output",

--- a/src/host/nufft_synthesis.hpp
+++ b/src/host/nufft_synthesis.hpp
@@ -28,6 +28,8 @@ public:
 
   auto get(View<T, 2> out) -> void override;
 
+  auto get_psf(View<T, 1> out) -> void override;
+
   auto type() const -> SynthesisType override { return SynthesisType::NUFFT; }
 
   auto context() -> const std::shared_ptr<ContextInternal>& override { return ctx_; }
@@ -46,6 +48,7 @@ private:
   std::size_t totalCollectCount_;
   std::size_t totalVisibilityCount_;
   HostArray<T, 2> img_;
+  HostArray<T, 1> psf_img_;
 };
 
 }  // namespace host

--- a/src/host/standard_synthesis.hpp
+++ b/src/host/standard_synthesis.hpp
@@ -5,6 +5,7 @@
 
 #include "bipp/bipp.h"
 #include "bipp/config.h"
+#include "bipp/exceptions.hpp"
 #include "bipp/standard_synthesis.hpp"
 #include "context_internal.hpp"
 #include "memory/array.hpp"
@@ -24,6 +25,10 @@ public:
   auto process(CollectorInterface<T>& collector) -> void override;
 
   auto get(View<T, 2> out) -> void override;
+
+  auto get_psf(View<T, 1> out) -> void override {
+    throw NotImplementedError();
+  }
 
   auto type() const -> SynthesisType override { return SynthesisType::Standard; }
 

--- a/src/imager.hpp
+++ b/src/imager.hpp
@@ -52,6 +52,8 @@ public:
 
   auto get(T* out, std::size_t ld) -> void;
 
+  auto get_psf(T* out) -> void;
+
   auto context() -> ContextInternal& { return *synthesis_->context(); };
 
 private:

--- a/src/nufft_synthesis.cpp
+++ b/src/nufft_synthesis.cpp
@@ -85,6 +85,22 @@ auto NufftSynthesis<T>::get(T* out, std::size_t ld) -> void {
   }
 }
 
+template <typename T>
+auto NufftSynthesis<T>::get_psf(T* out) -> void {
+  try {
+    reinterpret_cast<Imager<T>*>(plan_.get())->get_psf(out);
+  } catch (const std::exception& e) {
+    try {
+      reinterpret_cast<Imager<T>*>(plan_.get())
+          ->context()
+          .logger()
+          .log(BIPP_LOG_LEVEL_ERROR, "NufftSynthesis.get_psf() error: {}", e.what());
+    } catch (...) {
+    }
+    throw;
+  }
+}
+
 template class BIPP_EXPORT NufftSynthesis<double>;
 
 template class BIPP_EXPORT NufftSynthesis<float>;
@@ -167,6 +183,20 @@ BIPP_EXPORT BippError bipp_ns_options_set_normalize_image_by_nvis(BippNufftSynth
   }
   try {
     reinterpret_cast<NufftSynthesisOptions*>(opt)->set_normalize_image_by_nvis(normalize);
+  } catch (const bipp::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BIPP_UNKNOWN_ERROR;
+  }
+  return BIPP_SUCCESS;
+}
+
+BIPP_EXPORT BippError bipp_ns_options_set_psf(BippNufftSynthesisOptions opt, bool psf) {
+  if (!opt) {
+    return BIPP_INVALID_HANDLE_ERROR;
+  }
+  try {
+    reinterpret_cast<NufftSynthesisOptions*>(opt)->set_psf(psf);
   } catch (const bipp::GenericError& e) {
     return e.error_code();
   } catch (...) {
@@ -336,6 +366,20 @@ BIPP_EXPORT BippError bipp_nufft_synthesis_get_f(BippNufftSynthesisF plan, float
   return BIPP_SUCCESS;
 }
 
+BIPP_EXPORT BippError bipp_nufft_synthesis_get_psf_f(BippNufftSynthesisF plan, float* img) {
+  if (!plan) {
+    return BIPP_INVALID_HANDLE_ERROR;
+  }
+  try {
+    reinterpret_cast<NufftSynthesis<float>*>(plan)->get_psf(img);
+  } catch (const bipp::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BIPP_UNKNOWN_ERROR;
+  }
+  return BIPP_SUCCESS;
+}
+
 BIPP_EXPORT BippError bipp_nufft_synthesis_create(BippContext ctx, BippNufftSynthesisOptions opt,
                                                  size_t nImages,
                                                   size_t nPixel, const double* lmnX,
@@ -406,6 +450,21 @@ BIPP_EXPORT BippError bipp_nufft_synthesis_get(BippNufftSynthesis plan, double* 
   }
   return BIPP_SUCCESS;
 }
+
+BIPP_EXPORT BippError bipp_nufft_synthesis_get_psf(BippNufftSynthesisF plan, double* img){
+  if (!plan) {
+    return BIPP_INVALID_HANDLE_ERROR;
+  }
+  try {
+    reinterpret_cast<NufftSynthesis<double>*>(plan)->get_psf(img);
+  } catch (const bipp::GenericError& e) {
+    return e.error_code();
+  } catch (...) {
+    return BIPP_UNKNOWN_ERROR;
+  }
+  return BIPP_SUCCESS;
+}
+
 }
 
 }  // namespace bipp

--- a/src/synthesis_interface.hpp
+++ b/src/synthesis_interface.hpp
@@ -34,6 +34,8 @@ public:
 
   virtual auto get(View<T, 2> out) -> void = 0;
 
+  virtual auto get_psf(View<T, 1> out) -> void = 0;
+
   virtual auto type() const -> SynthesisType = 0;
 
   virtual auto context() -> const std::shared_ptr<ContextInternal>& = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
   find_package(nlohmann_json CONFIG REQUIRED)
 endif()
 
-list(APPEND BIPP_TEST_LIBRARIES gtest_main nlohmann_json::nlohmann_json)
+list(APPEND BIPP_TEST_LIBRARIES gtest nlohmann_json::nlohmann_json)
 
 # test executables
 add_executable(run_tests


### PR DESCRIPTION
This PR adds the option to generate the PSF by passing all input set to one to the nufft library.
The output can be retrieved through the `get_psf` function.