### PR TITLE
Moving to NumPy 2.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ set(BIPP_INSTALL_PYTHON_SUFFIX "platlib" CACHE STRING "Python installation suffi
 # Library install location
 set(BIPP_INSTALL_LIB_SUFFIX "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Lib install suffix")
 
-option(BIPP_BUNDLED_LIBS "Use bundled libraries for spdlog, googletest and json" ON)
+option(BIPP_BUNDLED_LIBS "Use bundled libraries for spdlog, pybind11, googletest and json" ON)
 cmake_dependent_option(BIPP_BUNDLED_SPDLOG "Use bundled spdlog lib" ON "BIPP_BUNDLED_LIBS" OFF)
 cmake_dependent_option(BIPP_BUNDLED_PYBIND11 "Use bundled pybind11 lib" ON "BIPP_BUNDLED_LIBS" OFF)
 cmake_dependent_option(BIPP_BUNDLED_GOOGLETEST "Use bundled googletest lib" ON "BIPP_BUNDLED_LIBS" OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,5 @@ requires = [
     "wheel",
     "scikit-build>=0.14.1",
     "cmake>=3.15",
-    "pybind11>=2.9",
-    "make",
-]
+    "pybind11>=2.12",
+    "make"]

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,8 +1,8 @@
 if (BIPP_BUNDLED_PYBIND11)
 	FetchContent_Declare(
 		pybind11
-		URL https://github.com/pybind/pybind11/archive/refs/tags/v2.10.4.tar.gz
-		URL_MD5 812eda11d2a114fc0e841faf9626d2c9
+		URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.tar.gz
+		URL_MD5 a04dead9c83edae6d84e2e343da7feeb
 	)
 	FetchContent_MakeAvailable(pybind11)
 else()
@@ -15,7 +15,7 @@ else()
 			OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ECHO STDOUT)
 	endif()
 
-	find_package(pybind11 CONFIG REQUIRED HINTS ${_pybind_dir})
+	find_package(pybind11 2.12 CONFIG REQUIRED HINTS ${_pybind_dir})
 endif()
 
 

--- a/python/bipp/array.py
+++ b/python/bipp/array.py
@@ -36,7 +36,7 @@ class LabeledMatrix:
             ):
                 raise ValueError("Parameter[data] must be CSC/CSR-ordered.")
         else:
-            self.__data = np.array(data, copy=False)
+            self.__data = np.asarray(data)
             self.__data.setflags(write=False)
 
             if self.__data.ndim != 2:
@@ -113,7 +113,8 @@ class LabeledMatrix:
         if not chk.is_instance(LabeledMatrix)(lmtx):
             raise ValueError("Parameter[lmtx] must be a LabeledMatrix.")
 
-        axes = np.array(axes, copy=False)
+        axes = np.asarray(axes)
+
         if not np.all((axes == 0) | (axes == 1)):
             raise ValueError("Parameter[axes] can only contain {0, 1}.")
 

--- a/python/bipp/gram.py
+++ b/python/bipp/gram.py
@@ -31,7 +31,7 @@ class GramMatrix(array.LabeledMatrix):
     """
 
     def __init__(self, data, beam_idx):
-        data = np.array(data, copy=False)
+        data = np.asarray(data)
         N_beam = len(beam_idx)
 
         if not chk.has_shape((N_beam, N_beam))(data):

--- a/python/bipp/imot_tools/io/s2image.py
+++ b/python/bipp/imot_tools/io/s2image.py
@@ -157,7 +157,7 @@ class Image:
         -----
         For efficiency reasons, `data` and `grid` are not copied internally.
         """
-        grid = np.array(grid, copy=False)
+        grid = np.asarray(grid)
         grid_shape_error_msg = (
             "Parameter[grid] must have shape (3, N_height, N_width) or (3, N_points)."
         )
@@ -171,7 +171,7 @@ class Image:
             raise ValueError(grid_shape_error_msg)
         self._grid = grid / linalg.norm(grid, axis=0)
 
-        data = np.array(data, copy=False)
+        data = np.asarray(data)
         if self._is_gridded:
             N_height, N_width = self._grid.shape[1:]
             if (data.ndim == 2) and chk.has_shape([N_height, N_width])(data):

--- a/python/bipp/imot_tools/math/func.py
+++ b/python/bipp/imot_tools/math/func.py
@@ -107,7 +107,7 @@ class Tukey:
         -------
         Tukey(T, beta, alpha)(x) : :py:class:`~numpy.ndarray`
         """
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         y = x - self._beta + self._T / 2
         left_lim = float(self._T * self._alpha / 2)
@@ -263,7 +263,7 @@ class SphericalDirichlet:
         if chk.is_scalar(x):
             x = np.array([x], dtype=float)
         else:
-            x = np.array(x, copy=False, dtype=float)
+            x = np.asarray(x, dtype=float)
 
         if not np.all((-1 <= x) & (x <= 1)):
             raise ValueError("Parameter[x] must lie in [-1, 1].")
@@ -354,8 +354,8 @@ class Kent:
             raise ValueError("Parameter[beta] must lie in [0, 1).")
         self._beta = beta
 
-        self._g1 = np.array(g1, copy=False) / linalg.norm(g1)
-        a = np.array(a, copy=False) / linalg.norm(a)
+        self._g1 = np.asarray(g1) / linalg.norm(g1)
+        a = np.asarray(a) / linalg.norm(a)
         if np.allclose(self._g1, a):
             raise ValueError("Parameters[g1, a] must not be colinear.")
 

--- a/python/bipp/imot_tools/math/linalg.py
+++ b/python/bipp/imot_tools/math/linalg.py
@@ -140,12 +140,12 @@ def eigh(A, B=None, tau=1, N=None):
         [ 0.0583+0.0055j  0.    +0.j      0.    +0.j    ]
         [ 0.0363+0.0209j  0.    +0.j      0.    +0.j    ]]
     """
-    A = np.array(A, copy=False)
+    A = np.asarray(A)
     M = len(A)
     if not (chk.has_shape([M, M])(A) and np.allclose(A, A.conj().T)):
         raise ValueError("Parameter[A] must be hermitian symmetric.")
 
-    B = np.eye(M) if (B is None) else np.array(B, copy=False)
+    B = np.eye(M) if (B is None) else np.asarray(B)
     if not (chk.has_shape([M, M])(B) and np.allclose(B, B.conj().T)):
         raise ValueError("Parameter[B] must be hermitian symmetric.")
 
@@ -228,7 +228,7 @@ def rot(axis, angle):
               [ 0.  ,  0.54,  0.84],
               [ 0.  , -0.84,  0.54]])
     """
-    axis = np.array(axis, copy=False)
+    axis = np.asarray(axis)
 
     a, b, c = axis / linalg.norm(axis)
     ct, st = np.cos(angle), np.sin(angle)
@@ -284,7 +284,7 @@ def z_rot2angle(R):
        >>> np.around(angle, 2)
        1.57
     """
-    R = np.array(R, copy=False)
+    R = np.asarray(R)
 
     if not np.allclose(R[[0, 1, 2, 2, 2], [2, 2, 2, 0, 1]], np.r_[0, 0, 1, 0, 0]):
         raise ValueError("Parameter[R] is not a rotation matrix around the Z-axis.")

--- a/python/bipp/imot_tools/math/sphere/grid.py
+++ b/python/bipp/imot_tools/math/sphere/grid.py
@@ -53,7 +53,7 @@ def spherical(direction, FoV, size):
     if not (0 < np.rad2deg(FoV) <= 179):
         raise ValueError("Parameter[FoV] must be in (0, 179] degrees.")
 
-    size = np.array(size, copy=False)
+    size = np.asarray(size)
     if np.any(size <= 0):
         raise ValueError("Parameter[size] must contain positive entries.")
 
@@ -111,7 +111,7 @@ def uniform(direction, FoV, size):
     if not (0 < np.rad2deg(FoV) <= 179):
         raise ValueError("Parameter[FoV] must be in (0, 179] degrees.")
 
-    size = np.array(size, copy=False)
+    size = np.asarray(size)
     if np.any(size <= 0):
         raise ValueError("Parameter[size] must contain positive entries.")
 

--- a/python/bipp/imot_tools/math/sphere/transform.py
+++ b/python/bipp/imot_tools/math/sphere/transform.py
@@ -126,7 +126,7 @@ def eq2cart(r, lat, lon):
               [0.],
               [0.]])
     """
-    r = np.array([r]) if chk.is_scalar(r) else np.array(r, copy=False)
+    r = np.array([r]) if chk.is_scalar(r) else np.asarray(r)
     if np.any(r < 0):
         raise ValueError("Parameter[r] must be non-negative.")
 

--- a/python/bipp/imot_tools/util/argcheck.py
+++ b/python/bipp/imot_tools/util/argcheck.py
@@ -517,7 +517,7 @@ def is_array_shape(x):
        False
     """
     if is_array_like(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if x.ndim == 1:
             if (len(x) > 0) and np.issubdtype(x.dtype, np.integer) and np.all(x > 0):
@@ -561,7 +561,7 @@ def has_shape(shape):
 
     def _has_shape(x):
         if is_array_like(x):
-            x = np.array(x, copy=False)
+            x = np.asarray(x)
         elif sparse.isspmatrix(x):
             pass
         else:
@@ -610,7 +610,7 @@ def has_ndim(ndim):
 
     def _has_ndim(x):
         if is_array_like(x):
-            x = np.array(x, copy=False)
+            x = np.asarray(x)
         else:
             return False
 
@@ -665,7 +665,7 @@ def has_integers(x):
        (False, False)
     """
     if is_array_like(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.issubdtype(x.dtype, np.integer):
             return True
@@ -718,7 +718,7 @@ def has_booleans(x):
        False
     """
     if is_array_like(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.issubdtype(x.dtype, np.bool_):
             return True
@@ -771,7 +771,7 @@ def has_evens(x):
        True
     """
     if has_integers(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.all(x % 2 == 0):
             return True
@@ -825,7 +825,7 @@ def has_odds(x):
        True
     """
     if has_integers(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.all(x % 2 == 1):
             return True
@@ -881,7 +881,7 @@ def has_pow2s(x):
        False
     """
     if has_integers(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.all(x > 0):
             exp = np.log2(x)
@@ -934,7 +934,7 @@ def has_complex(x):
        True
     """
     if is_array_like(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.issubdtype(x.dtype, np.complexfloating):
             return True
@@ -982,7 +982,7 @@ def has_reals(x):
        False
     """
     if is_array_like(x):
-        x = np.array(x, copy=False)
+        x = np.asarray(x)
 
         if np.issubdtype(x.dtype, np.integer) or np.issubdtype(x.dtype, np.floating):
             return True

--- a/python/bipp/instrument.py
+++ b/python/bipp/instrument.py
@@ -84,7 +84,7 @@ class InstrumentGeometry(array.LabeledMatrix):
     """
 
     def __init__(self, xyz, ant_idx):
-        xyz = np.array(xyz, copy=False)
+        xyz = np.asarray(xyz)
         N_antenna = len(xyz)
         if not chk.has_shape((N_antenna, 3))(xyz):
             raise ValueError("Parameter[xyz] must be a (N_antenna, 3) array.")

--- a/python/bipp/parameter_estimator.py
+++ b/python/bipp/parameter_estimator.py
@@ -119,7 +119,7 @@ class ParameterEstimator:
             G : :py:class:`~bipp.phased_array.bipp.gram.GramMatrix`
                 (N_beam, N_beam) gram matrix.
         """
-        D =  bipp.pybipp.eigh(self._ctx, wl,S, W, XYZ)
+        D = bipp.pybipp.eigh(self._ctx, wl,S, W, XYZ)
         D = D[D > 0.0]
         D = D[np.argsort(D)[::-1]]
         if self._fne:

--- a/python/bipp/statistics.py
+++ b/python/bipp/statistics.py
@@ -34,7 +34,7 @@ class VisibilityMatrix(array.LabeledMatrix):
     """
 
     def __init__(self, data, beam_idx):
-        data = np.array(data, copy=False)
+        data = np.asarray(data)
         N_beam = len(beam_idx)
 
         if not chk.has_shape((N_beam, N_beam))(data):

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     ]
     + bipp_cmake_args_list,
     install_requires=[
-        "numpy",
+        "numpy>2",
         "astropy",
         "matplotlib",
         "tqdm",


### PR DESCRIPTION
This PR to put BIPP on NumPy>2. The main changes are:
1. pybind11 2.12+ required, see https://pybind11.readthedocs.io/en/stable/
2. `np.array(..., copy=False)` calls changed to `np.asarray(...)`, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html

Without upgrading pybind11 a weird error arises about the impossibility to resize non-contiguous array here: https://github.com/epfl-radio-astro/bipp/blob/cd712c11bb6ed1c0a99513691b60fd73a5003b2f/python/pybipp.cpp#L137